### PR TITLE
Bridge processor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@
 # Virtual Environments
 *.venv
 .vscode/settings.json
+
+# Local data directory
+data/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+numpy<2
 boto3==1.35.5
 duckdb==1.0.0
 fqdn==1.5.1
@@ -12,3 +13,5 @@ openpyxl==3.1.5
 geopandas==1.0.1
 pyarrow==17.0.0
 python-dotenv==1.0.1
+fsspec==2025.10.0
+s3fs==2025.10.0

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+# Package root for ripple1d-pipeline

--- a/src/config.yaml
+++ b/src/config.yaml
@@ -8,6 +8,7 @@ paths:
   S3_UPLOAD_PREFIX: "" # Exclude trailing slash of S3 Bucket
   S3_UPLOAD_FAILED_PREFIX: "" # Exclude trailing slash of S3 Bucket
   MONITORING_DB_PATH: Z:\shared\monitoring.sqlite
+  BRIDGE_TILE_INDEX_PATH: s3://fimc-data/benchmark/stac-bench-cat/assets/bridge_index.parquet
 
 ripple_settings:
   RAS_VERSION: &RAS_VERSION "631"

--- a/src/config.yaml
+++ b/src/config.yaml
@@ -120,6 +120,10 @@ processing_steps:
       cleanup: True
       cog: True
 
+bridge_processing:
+  BRIDGE_ELEV_UNITS: "meters"
+  BRIDGE_ELEV_CONV_FACTOR: 3.28084  # Convert bridge elevation units to feet (units used by terrain and depth grids)
+
 flows2fim:
   FLOW_FILES_DIR: C:\reference_data\flow_files
   FLOWS2FIM_BIN_PATH: C:\OSGeo4W\bin\flows2fim.exe

--- a/src/config.yaml
+++ b/src/config.yaml
@@ -8,7 +8,7 @@ paths:
   S3_UPLOAD_PREFIX: "" # Exclude trailing slash of S3 Bucket
   S3_UPLOAD_FAILED_PREFIX: "" # Exclude trailing slash of S3 Bucket
   MONITORING_DB_PATH: Z:\shared\monitoring.sqlite
-  BRIDGE_TILE_INDEX_PATH: s3://fimc-data/benchmark/stac-bench-cat/assets/bridge_index.parquet
+  BRIDGE_TILE_INDEX_PATH: /vsis3/fimc-data/benchmark/stac-bench-cat/assets/bridge_index.parquet # All tiles in the tile index need to be in EPSG 5070 to work with ripple libraries
 
 ripple_settings:
   RAS_VERSION: &RAS_VERSION "631"

--- a/src/process/bridge_processor.py
+++ b/src/process/bridge_processor.py
@@ -1,63 +1,62 @@
 """
 Bridge processor module for masking depth library TIFs based on bridge locations.
 
-This module processes depth grids to adjust water depth values where bridges
-are located. The algorithm calculates Water Surface Elevation (WSE) and compares
-it to bridge elevations to determine if bridges are submerged or not.
+Uses GDAL/OGR command-line tools via subprocess for all operations.
+gdal_calc handles raster alignment automatically, eliminating need for explicit gdalwarp calls.
 """
 
+import json
 import logging
-import multiprocessing
-import os
 import shutil
+import subprocess
 import sys
 import tempfile
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
-
-import numpy as np
-import pandas as pd
-from osgeo import gdal
-from shapely.geometry import box
+from typing import TYPE_CHECKING, Dict, List, Tuple
 
 from .extent_library import setup_gdal_environment
 
-# Enable GDAL exceptions
-gdal.UseExceptions()
+if TYPE_CHECKING:
+    from ..setup.collection_data import CollectionData
 
 
-def get_raster_bounds(tif_path: Path) -> Tuple[float, float, float, float]:
-    """Get bounding box (xmin, ymin, xmax, ymax) of a raster file."""
-    ds = gdal.Open(str(tif_path))
-    gt, w, h = ds.GetGeoTransform(), ds.RasterXSize, ds.RasterYSize
-    ds = None
-    return gt[0], gt[3] + h * gt[5], gt[0] + w * gt[1], gt[3]
+def run_cmd(cmd: List, description: str) -> subprocess.CompletedProcess:
+    """Run a command and raise on failure. This packages the error handling pattern used several times in extent_library.py whenever subprocess.run is called there"""
+    result = subprocess.run([str(c) for c in cmd], capture_output=True, text=True)
+    if result.returncode != 0:
+        logging.debug(f"{description} stdout: {result.stdout}")
+        logging.error(f"{description} stderr: {result.stderr}")
+        logging.debug(f"Command: {' '.join(str(c) for c in cmd)}")
+        raise RuntimeError(f"{description} failed")
+    return result
 
 
-def align_raster_to_reference(
-    src_path: str, ref_ds: gdal.Dataset, output_path: str, resampling: int = gdal.GRA_Bilinear
-) -> Optional[str]:
-    """Align a source raster to match a reference raster's grid."""
-    gt, w, h = ref_ds.GetGeoTransform(), ref_ds.RasterXSize, ref_ds.RasterYSize
-    warp_options = gdal.WarpOptions(
-        format="GTiff",
-        outputBounds=(gt[0], gt[3] + h * gt[5], gt[0] + w * gt[1], gt[3]),
-        xRes=abs(gt[1]),
-        yRes=abs(gt[5]),
-        dstSRS=ref_ds.GetProjection(),
-        resampleAlg=resampling,
-        creationOptions=["COMPRESS=LZW"],
+def get_raster_info(tif_path: Path) -> Tuple[Tuple[float, float, float, float], float]:
+    """Get bounds (xmin, ymin, xmax, ymax) and nodata value from a raster."""
+    result = run_cmd(["gdalinfo", "-json", tif_path], f"gdalinfo {tif_path}")
+    info = json.loads(result.stdout)
+    corners = info["cornerCoordinates"]
+    bounds = (corners["upperLeft"][0], corners["lowerRight"][1], corners["lowerRight"][0], corners["upperLeft"][1])
+    nodata = info["bands"][0].get("noDataValue", -9999.0)
+    return bounds, nodata
+
+
+def query_bridge_index(bridge_index_path: str, bounds: Tuple[float, float, float, float]) -> List[str]:
+    """Query bridge index parquet for bridges intersecting the given bounds using OGR."""
+    xmin, ymin, xmax, ymax = bounds
+
+    # OGR flattens parquet structs: geometry_bbox.xmin, geometry_bbox.xmax, etc.
+    sql = (
+        f"SELECT location FROM bridge_index WHERE "
+        f'"geometry_bbox.xmin" <= {xmax} AND "geometry_bbox.xmax" >= {xmin} AND '
+        f'"geometry_bbox.ymin" <= {ymax} AND "geometry_bbox.ymax" >= {ymin}'
     )
-    try:
-        result = gdal.Warp(output_path, src_path, options=warp_options)
-        if result is None:
-            logging.error(f"Failed to warp {src_path}")
-            return None
-        result = None
-        return output_path
-    except Exception as e:
-        logging.error(f"Error aligning raster {src_path}: {e}")
-        return None
+
+    result = run_cmd(["ogr2ogr", "-f", "CSV", "/vsistdout/", bridge_index_path, "-sql", sql], "ogr2ogr bridge query")
+
+    # Parse CSV output (first line is header "location", rest are paths)
+    lines = result.stdout.strip().split("\n")
+    return lines[1:] if len(lines) > 1 else []
 
 
 def apply_bridge_mask(
@@ -66,138 +65,86 @@ def apply_bridge_mask(
     bridge_paths: List[str],
     output_path: Path,
     temp_dir: Path,
-    bridge_elev_conv_factor: float,
-) -> Tuple[bool, int]:
-    """Process a single depth TIF with bridge masking. Returns (success, pixels_modified)."""
+    conv_factor: float,
+    depth_nodata: float,
+) -> bool:
+    """
+    Process a single depth TIF with bridge masking.
+
+    gdal_calc handles alignment automatically - uses first input's grid,
+    resamples other inputs to match. No explicit gdalwarp needed.
+
+    GDAL calls: 2-3 (gdalbuildvrt if multiple bridges, gdal_calc, gdal_translate)
+    """
     try:
-        depth_ds = gdal.Open(str(depth_path))
-        if depth_ds is None:
-            logging.error(f"Failed to open depth raster: {depth_path}")
-            return False, 0
+        # Merge bridges into single VRT (skip if only one)
+        if len(bridge_paths) == 1:
+            bridges_input = bridge_paths[0]
+        else:
+            bridges_vrt = temp_dir / "bridges.vrt"
+            run_cmd(["gdalbuildvrt", bridges_vrt] + bridge_paths, "gdalbuildvrt")
+            bridges_input = bridges_vrt
 
-        depth_band = depth_ds.GetRasterBand(1)
-        depth_data = depth_band.ReadAsArray().astype(np.float32)
-        depth_nodata = depth_band.GetNoDataValue()
-
-        if not align_raster_to_reference(str(dem_path), depth_ds, str(temp_dir / "aligned_dem.tif")):
-            depth_ds = None
-            return False, 0
-
-        dem_ds = gdal.Open(str(temp_dir / "aligned_dem.tif"))
-        dem_data = dem_ds.GetRasterBand(1).ReadAsArray().astype(np.float32)
-        dem_ds = None
-
-        combined_mask = np.zeros(depth_data.shape, dtype=bool)
-        combined_elev = np.full(depth_data.shape, np.nan, dtype=np.float32)
-
-        for i, bridge_path in enumerate(bridge_paths):
-            aligned_path = str(temp_dir / f"aligned_bridge_{i}.tif")
-            if not align_raster_to_reference(bridge_path, depth_ds, aligned_path):
-                logging.warning(f"Failed to align bridge raster: {bridge_path}")
-                continue
-            bridge_ds = gdal.Open(aligned_path)
-            if bridge_ds is None:
-                continue
-            band = bridge_ds.GetRasterBand(1)
-            data, nodata = band.ReadAsArray().astype(np.float32), band.GetNoDataValue()
-            bridge_ds = None
-            valid = data != nodata
-            combined_mask |= valid
-            np.copyto(combined_elev, data * bridge_elev_conv_factor, where=valid)
-
-        # Apply masking algorithm
-        pixels_modified = 0
-        if np.any(combined_mask):
-            process_mask = combined_mask & (depth_data != depth_nodata)
-            if np.any(process_mask):
-                delta = (dem_data + depth_data) - combined_elev
-                above_water, submerged = process_mask & (delta < 0), process_mask & (delta >= 0)
-                pixels_modified = int(np.sum(above_water) + np.sum(submerged))
-                depth_data[above_water] = depth_nodata if depth_nodata is not None else -9999.0
-                depth_data[submerged] = delta[submerged]
-
-        temp_output = str(temp_dir / "temp_output.tif")
-        out_ds = gdal.GetDriverByName("GTiff").Create(
-            temp_output, depth_ds.RasterXSize, depth_ds.RasterYSize, 1, gdal.GDT_Float32, ["COMPRESS=LZW"]
+        # gdal_calc: A=depth (defines output grid), B=DEM, C=bridges
+        # Algorithm: delta = (DEM + depth) - bridge_elev * conv_factor
+        #   - bridge above water (delta < 0): set to nodata
+        #   - bridge submerged (delta >= 0): depth = delta
+        #   - no bridge (C is nodata): keep original depth
+        calc_expr = (
+            f"numpy.where((C == -9999) | numpy.isnan(C), A, "
+            f"numpy.where((B + A) - (C * {conv_factor}) < 0, {depth_nodata}, "
+            f"(B + A) - (C * {conv_factor})))"
         )
-        out_ds.SetGeoTransform(depth_ds.GetGeoTransform())
-        out_ds.SetProjection(depth_ds.GetProjection())
-        out_band = out_ds.GetRasterBand(1)
-        if depth_nodata is not None:
-            out_band.SetNoDataValue(depth_nodata)
-        out_band.WriteArray(depth_data)
-        out_ds.FlushCache()
-        out_ds = None
-        depth_ds = None
 
-        # Need to convert to cog with call to gdal.Translate because gdal's COG driver needs to read from an existing source
+        temp_output = temp_dir / "result.tif"
+        run_cmd(
+            [
+                "gdal_calc",
+                "-A",
+                depth_path,
+                "-B",
+                dem_path,
+                "-C",
+                bridges_input,
+                "--outfile",
+                temp_output,
+                f"--NoDataValue={depth_nodata}",
+                "--co=COMPRESS=LZW",
+                "--quiet",
+                f"--calc={calc_expr}",
+            ],
+            "gdal_calc",
+        )
+
+        # Convert to COG
         output_path.parent.mkdir(parents=True, exist_ok=True)
-        gdal.Translate(
-            str(output_path), temp_output, options=gdal.TranslateOptions(format="COG", creationOptions=["COMPRESS=LZW"])
-        )
-        return True, pixels_modified
+        run_cmd(["gdal_translate", "-of", "COG", "-co", "COMPRESS=LZW", temp_output, output_path], "gdal_translate")
+
+        return True
 
     except Exception as e:
         logging.error(f"Error processing {depth_path}: {e}", exc_info=True)
-        return False, 0
-
-
-def bridge_worker(args: tuple) -> Tuple[str, bool, int]:
-    """Worker for processing a single depth TIF. Returns (path, success, pixels_modified)."""
-    depth_path, dem_path, bridge_paths, output_path, temp_base_dir, bridge_elev_conv_factor = args
-    with tempfile.TemporaryDirectory(dir=temp_base_dir) as temp_dir:
-        if bridge_paths:
-            success, pixels_modified = apply_bridge_mask(
-                depth_path, dem_path, bridge_paths, output_path, Path(temp_dir), bridge_elev_conv_factor
-            )
-        else:
-            output_path.parent.mkdir(parents=True, exist_ok=True)
-            result = gdal.Translate(
-                str(output_path),
-                str(depth_path),
-                options=gdal.TranslateOptions(format="COG", creationOptions=["COMPRESS=LZW"]),
-            )
-            success, pixels_modified = result is not None, 0
-    return str(depth_path), success, pixels_modified
+        return False
 
 
 def process_bridges(collection: "CollectionData", print_progress: bool = False) -> Dict[str, any]:
     """
     Apply bridge masking to depth library TIFs.
 
-    This function reads the bridge tile index, processes each depth TIF
-    to adjust water depths where bridges intersect, and outputs the
-    results as Cloud Optimized GeoTIFFs.
-
-    Args:
-        collection: CollectionData object with configuration including:
-            - library_dir: Path to depth library with TIF files
-            - submodels_dir: Path to submodels with terrain data
-            - bridge_tile_index_path: S3 path to bridge index parquet
-        print_progress: Whether to display progress information
-
-    Returns:
-        Dict with processing statistics:
-            - total: Total number of TIFs processed
-            - success: Number of successful processes
-            - failed: Number of failed processes
-            - with_bridges: List of file paths that had bridge intersections
-            - without_bridges: List of file paths with no bridge intersections
-            - modified: List of file paths where depth values were actually modified
+    GDAL/OGR calls per TIF:
+      - No bridges: 2 (gdalinfo, ogr2ogr) + file copy
+      - With bridges: 5 (gdalinfo, ogr2ogr, gdalbuildvrt, gdal_calc, gdal_translate)
+      - Single bridge: 4 (gdalinfo, ogr2ogr, gdal_calc, gdal_translate)
     """
     library_dir = Path(collection.library_dir)
     submodels_dir = Path(collection.submodels_dir)
     bridge_index_path = collection.bridge_tile_index_path
-    process_count = collection.config["execution"]["OPTIMUM_PARALLEL_PROCESS_COUNT"]
-    bridge_elev_conv_factor = collection.config["bridge_processing"]["BRIDGE_ELEV_CONV_FACTOR"]
+    conv_factor = collection.config["bridge_processing"]["BRIDGE_ELEV_CONV_FACTOR"]
     _log = lambda m: print_progress and sys.stdout.write(m)
 
     setup_gdal_environment(collection)
 
-    _log(f"Loading bridge index from: {bridge_index_path}\n")
-    bridge_index = pd.read_parquet(bridge_index_path)
-    _log(f"Loaded {len(bridge_index)} bridge records\n")
-
+    # Rename library to temp, process into new library dir
     library_temp_dir = library_dir.parent / "library_temp"
     if library_temp_dir.exists():
         shutil.rmtree(library_temp_dir)
@@ -208,57 +155,56 @@ def process_bridges(collection: "CollectionData", print_progress: bool = False) 
     depth_tifs = list(library_temp_dir.rglob("*.tif"))
     _log(f"Found {len(depth_tifs)} depth TIFs to process\n")
 
-    worker_args, files_with_bridges, files_without_bridges = [], [], []
-    for depth_path in depth_tifs:
+    success_count, fail_count = 0, 0
+    files_with_bridges, files_without_bridges, files_modified = [], [], []
+
+    for i, depth_path in enumerate(depth_tifs, 1):
         reach_id = depth_path.parent.parent.name
         dem_files = list((submodels_dir / reach_id / "Terrain").glob("*.seamless_3dep_dem_3m_5070.tif"))
         if not dem_files:
             raise FileNotFoundError(f"No DEM found for reach {reach_id}")
+
+        # Get raster info and query bridges
         try:
-            raster_box = box(*get_raster_bounds(depth_path))
-            mask = bridge_index["geometry_bbox"].apply(
-                lambda bbox: raster_box.intersects(box(bbox["xmin"], bbox["ymin"], bbox["xmax"], bbox["ymax"]))
-            )
-            bridge_paths = bridge_index[mask]["location"].tolist()
+            bounds, depth_nodata = get_raster_info(depth_path)
+            bridge_paths = query_bridge_index(bridge_index_path, bounds)
         except Exception as e:
-            logging.error(f"Error querying bridges for {depth_path}: {e}")
-            bridge_paths = []
+            logging.error(f"Error reading {depth_path}: {e}")
+            fail_count += 1
+            continue
 
-        (files_with_bridges if bridge_paths else files_without_bridges).append(str(depth_path))
-        worker_args.append(
-            (
-                depth_path,
-                dem_files[0],
-                bridge_paths,
-                library_dir / depth_path.relative_to(library_temp_dir),
-                str(library_dir.parent),
-                bridge_elev_conv_factor,
-            )
-        )
+        output_path = library_dir / depth_path.relative_to(library_temp_dir)
 
-    success_count, fail_count, files_modified = 0, 0, []
-    with multiprocessing.Pool(process_count) as pool:
-        for i, (path, success, pixels_modified) in enumerate(pool.imap_unordered(bridge_worker, worker_args), 1):
-            if success:
-                success_count += 1
-                if pixels_modified > 0:
-                    files_modified.append(path)
-            else:
-                fail_count += 1
-                logging.error(f"Failed to process: {path}")
-            _log(f"\rProcessing: {i}/{len(worker_args)} (success: {success_count}, failed: {fail_count})")
-            print_progress and sys.stdout.flush()
+        if not bridge_paths:
+            # No bridges - copy file (already COG)
+            files_without_bridges.append(str(depth_path))
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(depth_path, output_path)
+            success_count += 1
+        else:
+            # Process with bridge masking
+            files_with_bridges.append(str(depth_path))
+            with tempfile.TemporaryDirectory(dir=str(library_dir.parent)) as temp_dir:
+                if apply_bridge_mask(
+                    depth_path, dem_files[0], bridge_paths, output_path, Path(temp_dir), conv_factor, depth_nodata
+                ):
+                    success_count += 1
+                    files_modified.append(str(depth_path))
+                else:
+                    fail_count += 1
+
+        _log(f"\rProcessing: {i}/{len(depth_tifs)} (success: {success_count}, failed: {fail_count})")
+        print_progress and sys.stdout.flush()
 
     _log(f"\nBridge processing complete: {success_count} succeeded, {fail_count} failed\n")
+
     if fail_count == 0:
-        _log(f"Removing temporary directory: {library_temp_dir}\n")
         shutil.rmtree(library_temp_dir)
     else:
         logging.warning(f"Keeping {library_temp_dir} due to {fail_count} failures")
-        _log(f"WARNING: Keeping {library_temp_dir} due to failures\n")
 
     return {
-        "total": len(worker_args),
+        "total": len(depth_tifs),
         "success": success_count,
         "failed": fail_count,
         "with_bridges": files_with_bridges,

--- a/src/process/bridge_processor.py
+++ b/src/process/bridge_processor.py
@@ -130,6 +130,7 @@ def apply_bridge_mask(
         out_ds = None
         depth_ds = None
 
+        # Need to convert to cog with call to gdal.Translate because gdal's COG driver needs to read from an existing source
         output_path.parent.mkdir(parents=True, exist_ok=True)
         gdal.Translate(
             str(output_path), temp_output, options=gdal.TranslateOptions(format="COG", creationOptions=["COMPRESS=LZW"])

--- a/src/process/bridge_processor.py
+++ b/src/process/bridge_processor.py
@@ -14,10 +14,8 @@ import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, List, Tuple
 
+from ..setup.collection_data import CollectionData
 from .extent_library import setup_gdal_environment
-
-if TYPE_CHECKING:
-    from ..setup.collection_data import CollectionData
 
 
 def run_cmd(cmd: List, description: str) -> subprocess.CompletedProcess:
@@ -76,104 +74,73 @@ def align_raster(
     run_cmd(cmd, f"gdalwarp align {src_path}")
 
 
-def apply_bridge_mask(
-    depth_path: Path,
-    dem_path: Path,
-    bridge_paths: List[str],
-    output_path: Path,
-    temp_dir: Path,
-    conv_factor: float,
-    depth_bounds: Tuple[float, float, float, float],
-    depth_res: Tuple[float, float],
-    depth_nodata: float,
-) -> bool:
+def apply_bridge_mask(args: Tuple) -> Tuple[str, bool]:
     """
-    Process a single depth TIF with bridge masking.
+    Process a single depth TIF with bridge masking (worker function for multiprocessing).
 
     Uses gdalwarp to align DEM and bridge rasters to match the depth TIF's grid,
-    then applies gdal_calc for the masking computation.
+    then applies gdal_calc for the masking computation. Overwrites the original file on success.
     """
-    try:
-        # Merge bridges into single VRT (skip if only one)
-        if len(bridge_paths) == 1:
-            bridges_input = bridge_paths[0]
-        else:
-            bridges_vrt = temp_dir / "bridges.vrt"
-            run_cmd(["gdalbuildvrt", bridges_vrt] + bridge_paths, "gdalbuildvrt")
-            bridges_input = bridges_vrt
-
-        # Align DEM and bridges to depth grid
-        aligned_dem = temp_dir / "aligned_dem.vrt"
-        align_raster(dem_path, aligned_dem, depth_bounds, depth_res)
-
-        aligned_bridges = temp_dir / "aligned_bridges.vrt"
-        align_raster(Path(bridges_input), aligned_bridges, depth_bounds, depth_res, nodata=-9999)
-
-        # gdal_calc: A=depth, B=aligned DEM, C=aligned bridges
-        # Algorithm: delta = (DEM + depth) - bridge_elev * conv_factor
-        #   - bridge above water (delta < 0): set to nodata
-        #   - bridge submerged (delta >= 0): depth = delta
-        #   - no bridge (C is nodata): keep original depth
-        calc_expr = (
-            f"numpy.where((C == -9999) | numpy.isnan(C), A, "
-            f"numpy.where((B + A) - (C * {conv_factor}) < 0, {depth_nodata}, "
-            f"(B + A) - (C * {conv_factor})))"
-        )
-
-        temp_output = temp_dir / "result.tif"
-        run_cmd(
-            [
-                "gdal_calc",
-                "-A",
-                depth_path,
-                "-B",
-                aligned_dem,
-                "-C",
-                aligned_bridges,
-                "--outfile",
-                temp_output,
-                f"--NoDataValue={depth_nodata}",
-                "--co=COMPRESS=LZW",
-                "--quiet",
-                f"--calc={calc_expr}",
-            ],
-            "gdal_calc",
-        )
-
-        # Convert to COG
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-        run_cmd(["gdal_translate", "-of", "COG", "-co", "COMPRESS=LZW", temp_output, output_path], "gdal_translate")
-
-        return True
-
-    except Exception as e:
-        logging.error(f"Error processing {depth_path}: {e}", exc_info=True)
-        return False
-
-
-def _process_single_depth(args: Tuple) -> Tuple[str, bool]:
-    """Worker function for parallel bridge masking."""
     depth_path, dem_path, bridge_paths, library_parent, conv_factor, bounds, depth_res, depth_nodata = args
     depth_path = Path(depth_path)
     dem_path = Path(dem_path)
 
-    with tempfile.TemporaryDirectory(dir=str(library_parent)) as temp_dir:
-        temp_output = Path(temp_dir) / "output.tif"
-        if apply_bridge_mask(
-            depth_path,
-            dem_path,
-            bridge_paths,
-            temp_output,
-            Path(temp_dir),
-            conv_factor,
-            bounds,
-            depth_res,
-            depth_nodata,
-        ):
-            shutil.move(str(temp_output), str(depth_path))
-            return (str(depth_path), True)
-        else:
-            return (str(depth_path), False)
+    try:
+        with tempfile.TemporaryDirectory(dir=library_parent) as temp_dir:
+            temp_dir = Path(temp_dir)
+
+            # Merge bridges into single VRT
+            bridges_vrt = temp_dir / "bridges.vrt"
+            run_cmd(["gdalbuildvrt", bridges_vrt] + bridge_paths, "gdalbuildvrt")
+
+            # Align DEM and bridges to depth grid
+            aligned_dem = temp_dir / "aligned_dem.vrt"
+            align_raster(dem_path, aligned_dem, bounds, depth_res)
+
+            aligned_bridges = temp_dir / "aligned_bridges.vrt"
+            align_raster(bridges_vrt, aligned_bridges, bounds, depth_res, nodata=-9999)
+
+            # gdal_calc: A=depth, B=aligned DEM, C=aligned bridges
+            # Algorithm: delta = (DEM + depth) - bridge_elev * conv_factor
+            #   - bridge above water (delta < 0): set to nodata
+            #   - bridge submerged (delta >= 0): depth = delta
+            #   - no bridge (C is nodata): keep original depth
+            calc_expr = (
+                f"numpy.where((C == -9999) | numpy.isnan(C), A, "
+                f"numpy.where((B + A) - (C * {conv_factor}) < 0, {depth_nodata}, "
+                f"(B + A) - (C * {conv_factor})))"
+            )
+
+            temp_output = temp_dir / "result.tif"
+            run_cmd(
+                [
+                    "gdal_calc",
+                    "-A",
+                    depth_path,
+                    "-B",
+                    aligned_dem,
+                    "-C",
+                    aligned_bridges,
+                    "--outfile",
+                    temp_output,
+                    f"--NoDataValue={depth_nodata}",
+                    "--co=COMPRESS=LZW",
+                    "--quiet",
+                    f"--calc={calc_expr}",
+                ],
+                "gdal_calc",
+            )
+
+            # Convert to COG and overwrite original
+            cog_output = temp_dir / "output.tif"
+            run_cmd(["gdal_translate", "-of", "COG", "-co", "COMPRESS=LZW", temp_output, cog_output], "gdal_translate")
+            shutil.move(str(cog_output), str(depth_path))
+
+        return (str(depth_path), True)
+
+    except Exception as e:
+        logging.error(f"Error processing {depth_path}: {e}", exc_info=True)
+        return (str(depth_path), False)
 
 
 def process_bridges(collection: "CollectionData", print_progress: bool = False) -> Dict[str, any]:
@@ -260,7 +227,7 @@ def process_bridges(collection: "CollectionData", print_progress: bool = False) 
 
         num_workers = collection.config["execution"]["OPTIMUM_PARALLEL_PROCESS_COUNT"]
         with multiprocessing.Pool(processes=num_workers) as pool:
-            for depth_path, success in pool.imap_unordered(_process_single_depth, worker_args):
+            for depth_path, success in pool.imap_unordered(apply_bridge_mask, worker_args):
                 if success:
                     success_count += 1
                     files_modified.append(depth_path)

--- a/src/process/bridge_processor.py
+++ b/src/process/bridge_processor.py
@@ -1,7 +1,7 @@
 """
 Bridge processor module for masking depth library TIFs based on bridge locations.
 
-Uses GDAL/OGR command-line tools via subprocess for all operations.
+Uses GDAL/OGR command-line tools via subprocess for all operations. This has benefits of maintainability and also easier debugging if you have existing intermediate outputs before the subprocess call.
 """
 
 import json
@@ -9,13 +9,12 @@ import logging
 import multiprocessing
 import shutil
 import subprocess
-import sys
 import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, List, Tuple
 
 from ..setup.collection_data import CollectionData
-from .extent_library import setup_gdal_environment
+from .extent_library import get_all_tif_paths, setup_gdal_environment
 
 
 def run_cmd(cmd: List, description: str) -> subprocess.CompletedProcess:
@@ -78,29 +77,16 @@ def apply_bridge_mask(args: Tuple) -> Tuple[str, bool]:
     """
     Process a single depth TIF with bridge masking (worker function for multiprocessing).
 
-    Uses gdalwarp to align DEM and bridge rasters to match the depth TIF's grid,
-    then applies gdal_calc for the masking computation. Overwrites the original file on success.
+    Expects pre-aligned DEM and bridge VRTs. Runs gdal_calc for the masking computation
+    and overwrites the original file on success.
     """
-    depth_path, dem_path, bridge_paths, library_parent, conv_factor, bounds, depth_res, depth_nodata = args
+    depth_path, aligned_dem, aligned_bridges, library_parent, conv_factor, depth_nodata = args
     depth_path = Path(depth_path)
-    dem_path = Path(dem_path)
 
     try:
         with tempfile.TemporaryDirectory(dir=library_parent) as temp_dir:
             temp_dir = Path(temp_dir)
 
-            # Merge bridges into single VRT
-            bridges_vrt = temp_dir / "bridges.vrt"
-            run_cmd(["gdalbuildvrt", bridges_vrt] + bridge_paths, "gdalbuildvrt")
-
-            # Align DEM and bridges to depth grid
-            aligned_dem = temp_dir / "aligned_dem.vrt"
-            align_raster(dem_path, aligned_dem, bounds, depth_res)
-
-            aligned_bridges = temp_dir / "aligned_bridges.vrt"
-            align_raster(bridges_vrt, aligned_bridges, bounds, depth_res, nodata=-9999)
-
-            # gdal_calc: A=depth, B=aligned DEM, C=aligned bridges
             # Algorithm: delta = (DEM + depth) - bridge_elev * conv_factor
             #   - bridge above water (delta < 0): set to nodata
             #   - bridge submerged (delta >= 0): depth = delta
@@ -131,7 +117,7 @@ def apply_bridge_mask(args: Tuple) -> Tuple[str, bool]:
                 "gdal_calc",
             )
 
-            # Convert to COG and overwrite original
+            # gdal_calc can't work with COG so need to convert here
             cog_output = temp_dir / "output.tif"
             run_cmd(["gdal_translate", "-of", "COG", "-co", "COMPRESS=LZW", temp_output, cog_output], "gdal_translate")
             shutil.move(str(cog_output), str(depth_path))
@@ -147,16 +133,18 @@ def process_bridges(collection: "CollectionData", print_progress: bool = False) 
     """
     Apply bridge masking to depth library TIFs in place.
     """
+    if print_progress:
+        logging.getLogger().setLevel(logging.INFO)
+
     library_dir = Path(collection.library_dir)
     submodels_dir = Path(collection.submodels_dir)
     bridge_index_path = collection.bridge_tile_index_path
     conv_factor = collection.config["bridge_processing"]["BRIDGE_ELEV_CONV_FACTOR"]
-    _log = lambda m: print_progress and sys.stdout.write(m)
 
     setup_gdal_environment(collection)
 
-    depth_tifs = list(library_dir.rglob("*.tif"))
-    _log(f"Found {len(depth_tifs)} depth TIFs to process\n")
+    depth_tifs = get_all_tif_paths(library_dir)
+    logging.info(f"Found {len(depth_tifs)} depth TIFs to process")
 
     reaches: Dict[str, List[Path]] = {}
     for tif in depth_tifs:
@@ -171,7 +159,7 @@ def process_bridges(collection: "CollectionData", print_progress: bool = False) 
         if not dem_path.exists():
             raise FileNotFoundError(f"No DEM found for reach {reach_id}: {dem_path}")
 
-        # Query bridges once per reach (all TIFs have same bounds and nodata)
+        # The bridge query requires that all bridge tiles be in epsg 5070
         try:
             bounds, depth_res, depth_nodata = get_raster_info(reach_tifs[0])
             xmin, ymin, xmax, ymax = bounds
@@ -206,38 +194,48 @@ def process_bridges(collection: "CollectionData", print_progress: bool = False) 
                 files_without_bridges.append(str(depth_path))
                 success_count += 1
                 processed += 1
-                _log(f"\rProcessing: {processed}/{len(depth_tifs)} (success: {success_count}, failed: {fail_count})")
-                print_progress and sys.stdout.flush()
+            logging.info(f"Reach {reach_id}: no bridges, skipped {len(reach_tifs)} TIFs")
             continue
 
         files_with_bridges.extend(str(p) for p in reach_tifs)
-        worker_args = [
-            (
-                str(depth_path),
-                str(dem_path),
-                bridge_paths,
-                str(library_dir.parent),
-                conv_factor,
-                bounds,
-                depth_res,
-                depth_nodata,
-            )
-            for depth_path in reach_tifs
-        ]
 
-        num_workers = collection.config["execution"]["OPTIMUM_PARALLEL_PROCESS_COUNT"]
-        with multiprocessing.Pool(processes=num_workers) as pool:
-            for depth_path, success in pool.imap_unordered(apply_bridge_mask, worker_args):
-                if success:
-                    success_count += 1
-                    files_modified.append(depth_path)
-                else:
-                    fail_count += 1
-                processed += 1
-                _log(f"\rProcessing: {processed}/{len(depth_tifs)} (success: {success_count}, failed: {fail_count})")
-                print_progress and sys.stdout.flush()
+        with tempfile.TemporaryDirectory(dir=str(library_dir.parent)) as reach_temp_dir:
+            reach_temp_dir = Path(reach_temp_dir)
 
-    _log(f"\nBridge processing complete: {success_count} succeeded, {fail_count} failed\n")
+            bridges_vrt = reach_temp_dir / "bridges.vrt"
+            run_cmd(["gdalbuildvrt", bridges_vrt] + bridge_paths, "gdalbuildvrt")
+
+            aligned_dem = reach_temp_dir / "aligned_dem.vrt"
+            align_raster(dem_path, aligned_dem, bounds, depth_res)
+
+            aligned_bridges = reach_temp_dir / "aligned_bridges.vrt"
+            align_raster(bridges_vrt, aligned_bridges, bounds, depth_res, nodata=-9999)
+
+            worker_args = [
+                (
+                    str(depth_path),
+                    str(aligned_dem),
+                    str(aligned_bridges),
+                    str(library_dir.parent),
+                    conv_factor,
+                    depth_nodata,
+                )
+                for depth_path in reach_tifs
+            ]
+
+            num_workers = collection.config["execution"]["OPTIMUM_PARALLEL_PROCESS_COUNT"]
+            with multiprocessing.Pool(processes=num_workers) as pool:
+                for depth_path, success in pool.imap_unordered(apply_bridge_mask, worker_args):
+                    if success:
+                        success_count += 1
+                        files_modified.append(depth_path)
+                    else:
+                        fail_count += 1
+                    processed += 1
+
+            logging.info(f"Reach {reach_id}: processed {len(reach_tifs)} TIFs with {len(bridge_paths)} bridges")
+
+    logging.info(f"Bridge processing complete: {success_count} succeeded, {fail_count} failed")
 
     return {
         "total": len(depth_tifs),

--- a/src/process/bridge_processor.py
+++ b/src/process/bridge_processor.py
@@ -2,11 +2,11 @@
 Bridge processor module for masking depth library TIFs based on bridge locations.
 
 Uses GDAL/OGR command-line tools via subprocess for all operations.
-gdal_calc handles raster alignment automatically, eliminating need for explicit gdalwarp calls.
 """
 
 import json
 import logging
+import multiprocessing
 import shutil
 import subprocess
 import sys
@@ -31,32 +31,49 @@ def run_cmd(cmd: List, description: str) -> subprocess.CompletedProcess:
     return result
 
 
-def get_raster_info(tif_path: Path) -> Tuple[Tuple[float, float, float, float], float]:
-    """Get bounds (xmin, ymin, xmax, ymax) and nodata value from a raster."""
+def get_raster_info(tif_path: Path) -> Tuple[Tuple[float, float, float, float], Tuple[float, float], float]:
+    """Get bounds (xmin, ymin, xmax, ymax), resolution (xres, yres), and nodata value from a raster."""
     result = run_cmd(["gdalinfo", "-json", tif_path], f"gdalinfo {tif_path}")
     info = json.loads(result.stdout)
     corners = info["cornerCoordinates"]
     bounds = (corners["upperLeft"][0], corners["lowerRight"][1], corners["lowerRight"][0], corners["upperLeft"][1])
+    # geoTransform: [originX, pixelWidth, 0, originY, 0, pixelHeight]
+    gt = info["geoTransform"]
+    res = (abs(gt[1]), abs(gt[5]))
     nodata = info["bands"][0].get("noDataValue", -9999.0)
-    return bounds, nodata
+    return bounds, res, nodata
 
 
-def query_bridge_index(bridge_index_path: str, bounds: Tuple[float, float, float, float]) -> List[str]:
-    """Query bridge index parquet for bridges intersecting the given bounds using OGR."""
+def align_raster(
+    src_path: Path,
+    output_path: Path,
+    bounds: Tuple[float, float, float, float],
+    res: Tuple[float, float],
+    nodata: float = None,
+) -> None:
+    """Align a raster to the specified extent and resolution, outputting a VRT."""
     xmin, ymin, xmax, ymax = bounds
-
-    # OGR flattens parquet structs: geometry_bbox.xmin, geometry_bbox.xmax, etc.
-    sql = (
-        f"SELECT location FROM bridge_index WHERE "
-        f'"geometry_bbox.xmin" <= {xmax} AND "geometry_bbox.xmax" >= {xmin} AND '
-        f'"geometry_bbox.ymin" <= {ymax} AND "geometry_bbox.ymax" >= {ymin}'
-    )
-
-    result = run_cmd(["ogr2ogr", "-f", "CSV", "/vsistdout/", bridge_index_path, "-sql", sql], "ogr2ogr bridge query")
-
-    # Parse CSV output (first line is header "location", rest are paths)
-    lines = result.stdout.strip().split("\n")
-    return lines[1:] if len(lines) > 1 else []
+    xres, yres = res
+    cmd = [
+        "gdalwarp",
+        "-overwrite",
+        "-of",
+        "VRT",
+        "-te",
+        xmin,
+        ymin,
+        xmax,
+        ymax,
+        "-tr",
+        xres,
+        yres,
+        "-r",
+        "bilinear",
+    ]
+    if nodata is not None:
+        cmd.extend(["-dstnodata", nodata])
+    cmd.extend([src_path, output_path])
+    run_cmd(cmd, f"gdalwarp align {src_path}")
 
 
 def apply_bridge_mask(
@@ -66,15 +83,15 @@ def apply_bridge_mask(
     output_path: Path,
     temp_dir: Path,
     conv_factor: float,
+    depth_bounds: Tuple[float, float, float, float],
+    depth_res: Tuple[float, float],
     depth_nodata: float,
 ) -> bool:
     """
     Process a single depth TIF with bridge masking.
 
-    gdal_calc handles alignment automatically - uses first input's grid,
-    resamples other inputs to match. No explicit gdalwarp needed.
-
-    GDAL calls: 2-3 (gdalbuildvrt if multiple bridges, gdal_calc, gdal_translate)
+    Uses gdalwarp to align DEM and bridge rasters to match the depth TIF's grid,
+    then applies gdal_calc for the masking computation.
     """
     try:
         # Merge bridges into single VRT (skip if only one)
@@ -85,7 +102,14 @@ def apply_bridge_mask(
             run_cmd(["gdalbuildvrt", bridges_vrt] + bridge_paths, "gdalbuildvrt")
             bridges_input = bridges_vrt
 
-        # gdal_calc: A=depth (defines output grid), B=DEM, C=bridges
+        # Align DEM and bridges to depth grid
+        aligned_dem = temp_dir / "aligned_dem.vrt"
+        align_raster(dem_path, aligned_dem, depth_bounds, depth_res)
+
+        aligned_bridges = temp_dir / "aligned_bridges.vrt"
+        align_raster(Path(bridges_input), aligned_bridges, depth_bounds, depth_res, nodata=-9999)
+
+        # gdal_calc: A=depth, B=aligned DEM, C=aligned bridges
         # Algorithm: delta = (DEM + depth) - bridge_elev * conv_factor
         #   - bridge above water (delta < 0): set to nodata
         #   - bridge submerged (delta >= 0): depth = delta
@@ -103,9 +127,9 @@ def apply_bridge_mask(
                 "-A",
                 depth_path,
                 "-B",
-                dem_path,
+                aligned_dem,
                 "-C",
-                bridges_input,
+                aligned_bridges,
                 "--outfile",
                 temp_output,
                 f"--NoDataValue={depth_nodata}",
@@ -127,14 +151,34 @@ def apply_bridge_mask(
         return False
 
 
+def _process_single_depth(args: Tuple) -> Tuple[str, bool]:
+    """Worker function for parallel bridge masking."""
+    depth_path, dem_path, bridge_paths, library_parent, conv_factor, bounds, depth_res, depth_nodata = args
+    depth_path = Path(depth_path)
+    dem_path = Path(dem_path)
+
+    with tempfile.TemporaryDirectory(dir=str(library_parent)) as temp_dir:
+        temp_output = Path(temp_dir) / "output.tif"
+        if apply_bridge_mask(
+            depth_path,
+            dem_path,
+            bridge_paths,
+            temp_output,
+            Path(temp_dir),
+            conv_factor,
+            bounds,
+            depth_res,
+            depth_nodata,
+        ):
+            shutil.move(str(temp_output), str(depth_path))
+            return (str(depth_path), True)
+        else:
+            return (str(depth_path), False)
+
+
 def process_bridges(collection: "CollectionData", print_progress: bool = False) -> Dict[str, any]:
     """
-    Apply bridge masking to depth library TIFs.
-
-    GDAL/OGR calls per TIF:
-      - No bridges: 2 (gdalinfo, ogr2ogr) + file copy
-      - With bridges: 5 (gdalinfo, ogr2ogr, gdalbuildvrt, gdal_calc, gdal_translate)
-      - Single bridge: 4 (gdalinfo, ogr2ogr, gdal_calc, gdal_translate)
+    Apply bridge masking to depth library TIFs in place.
     """
     library_dir = Path(collection.library_dir)
     submodels_dir = Path(collection.submodels_dir)
@@ -144,64 +188,89 @@ def process_bridges(collection: "CollectionData", print_progress: bool = False) 
 
     setup_gdal_environment(collection)
 
-    # Rename library to temp, process into new library dir
-    library_temp_dir = library_dir.parent / "library_temp"
-    if library_temp_dir.exists():
-        shutil.rmtree(library_temp_dir)
-    _log(f"Renaming {library_dir} to {library_temp_dir}\n")
-    shutil.move(str(library_dir), str(library_temp_dir))
-    library_dir.mkdir(parents=True, exist_ok=True)
-
-    depth_tifs = list(library_temp_dir.rglob("*.tif"))
+    depth_tifs = list(library_dir.rglob("*.tif"))
     _log(f"Found {len(depth_tifs)} depth TIFs to process\n")
 
-    success_count, fail_count = 0, 0
+    reaches: Dict[str, List[Path]] = {}
+    for tif in depth_tifs:
+        reach_id = tif.parent.parent.name
+        reaches.setdefault(reach_id, []).append(tif)
+
+    success_count, fail_count, processed = 0, 0, 0
     files_with_bridges, files_without_bridges, files_modified = [], [], []
 
-    for i, depth_path in enumerate(depth_tifs, 1):
-        reach_id = depth_path.parent.parent.name
-        dem_files = list((submodels_dir / reach_id / "Terrain").glob("*.seamless_3dep_dem_3m_5070.tif"))
-        if not dem_files:
-            raise FileNotFoundError(f"No DEM found for reach {reach_id}")
+    for reach_id, reach_tifs in reaches.items():
+        dem_path = submodels_dir / reach_id / "Terrain" / f"{reach_id}.seamless_3dep_dem_3m_5070.tif"
+        if not dem_path.exists():
+            raise FileNotFoundError(f"No DEM found for reach {reach_id}: {dem_path}")
 
-        # Get raster info and query bridges
+        # Query bridges once per reach (all TIFs have same bounds and nodata)
         try:
-            bounds, depth_nodata = get_raster_info(depth_path)
-            bridge_paths = query_bridge_index(bridge_index_path, bounds)
+            bounds, depth_res, depth_nodata = get_raster_info(reach_tifs[0])
+            xmin, ymin, xmax, ymax = bounds
+            result = run_cmd(
+                [
+                    "ogr2ogr",
+                    "-f",
+                    "CSV",
+                    "-spat",
+                    xmin,
+                    ymin,
+                    xmax,
+                    ymax,
+                    "-select",
+                    "location",
+                    "/vsistdout/",
+                    bridge_index_path,
+                ],
+                "ogr2ogr bridge query",
+            )
+            lines = result.stdout.strip().split("\n")
+            bridge_paths = lines[1:] if len(lines) > 1 else []
         except Exception as e:
-            logging.error(f"Error reading {depth_path}: {e}")
-            fail_count += 1
+            logging.error(f"Error querying bridges for reach {reach_id}: {e}")
+            fail_count += len(reach_tifs)
+            processed += len(reach_tifs)
             continue
 
-        output_path = library_dir / depth_path.relative_to(library_temp_dir)
-
         if not bridge_paths:
-            # No bridges - copy file (already COG)
-            files_without_bridges.append(str(depth_path))
-            output_path.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copy2(depth_path, output_path)
-            success_count += 1
-        else:
-            # Process with bridge masking
-            files_with_bridges.append(str(depth_path))
-            with tempfile.TemporaryDirectory(dir=str(library_dir.parent)) as temp_dir:
-                if apply_bridge_mask(
-                    depth_path, dem_files[0], bridge_paths, output_path, Path(temp_dir), conv_factor, depth_nodata
-                ):
+            # No bridges in this reach - nothing to do
+            for depth_path in reach_tifs:
+                files_without_bridges.append(str(depth_path))
+                success_count += 1
+                processed += 1
+                _log(f"\rProcessing: {processed}/{len(depth_tifs)} (success: {success_count}, failed: {fail_count})")
+                print_progress and sys.stdout.flush()
+            continue
+
+        files_with_bridges.extend(str(p) for p in reach_tifs)
+        worker_args = [
+            (
+                str(depth_path),
+                str(dem_path),
+                bridge_paths,
+                str(library_dir.parent),
+                conv_factor,
+                bounds,
+                depth_res,
+                depth_nodata,
+            )
+            for depth_path in reach_tifs
+        ]
+
+        num_workers = collection.config["execution"]["OPTIMUM_PARALLEL_PROCESS_COUNT"]
+        with multiprocessing.Pool(processes=num_workers) as pool:
+            for depth_path, success in pool.imap_unordered(_process_single_depth, worker_args):
+                if success:
                     success_count += 1
-                    files_modified.append(str(depth_path))
+                    files_modified.append(depth_path)
                 else:
                     fail_count += 1
-
-        _log(f"\rProcessing: {i}/{len(depth_tifs)} (success: {success_count}, failed: {fail_count})")
-        print_progress and sys.stdout.flush()
+                processed += 1
+                _log(f"\rProcessing: {processed}/{len(depth_tifs)} (success: {success_count}, failed: {fail_count})")
+                print_progress and sys.stdout.flush()
 
     _log(f"\nBridge processing complete: {success_count} succeeded, {fail_count} failed\n")
-
-    if fail_count == 0:
-        shutil.rmtree(library_temp_dir)
-    else:
-        logging.warning(f"Keeping {library_temp_dir} due to {fail_count} failures")
 
     return {
         "total": len(depth_tifs),

--- a/src/process/bridge_processor.py
+++ b/src/process/bridge_processor.py
@@ -107,6 +107,7 @@ def apply_bridge_mask(args: Tuple) -> Tuple[str, bool]:
             run_cmd(
                 [
                     "gdal_calc",
+                    "--hideNoData",  # If you don't pass this flag then gdal_calc will not evaluate pixels where one source is no data. This blanks out the depth raster since most of the bridge raster is nodata
                     "-A",
                     depth_path,
                     "-B",

--- a/src/process/bridge_processor.py
+++ b/src/process/bridge_processor.py
@@ -1,0 +1,501 @@
+"""
+Bridge processor module for masking depth library TIFs based on bridge locations.
+
+This module processes depth grids to adjust water depth values where bridges
+are located. The algorithm calculates Water Surface Elevation (WSE) and compares
+it to bridge deck elevations to determine if water flows over or under bridges.
+
+Processing Steps:
+1. Query bridge tile index for intersecting bridges
+2. If intersection: load depth, DEM, and bridge rasters
+3. Align all rasters to depth grid
+4. Calculate WSE = DEM_elevation + depth
+5. Adjust depth based on bridge comparison:
+   - If bridge > WSE (dry): set depth = 0
+   - If bridge < WSE (submerged): set depth = WSE - bridge_elevation
+"""
+
+import logging
+import multiprocessing
+import os
+import shutil
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
+
+import numpy as np
+import pandas as pd
+from osgeo import gdal
+
+from .extent_library import setup_gdal_environment
+
+if TYPE_CHECKING:
+    from ..setup.collection_data import CollectionData
+
+# Enable GDAL exceptions
+gdal.UseExceptions()
+
+# S3 storage options for pandas
+S3_STORAGE_OPTIONS = {"profile": "fimbucket"}
+
+
+def load_bridge_index(bridge_index_path: str) -> pd.DataFrame:
+    """
+    Load the bridge tile index from S3 or local path.
+
+    Args:
+        bridge_index_path: Path to bridge index parquet (S3 or local)
+
+    Returns:
+        DataFrame with bridge index data
+    """
+    if bridge_index_path.startswith("s3://"):
+        return pd.read_parquet(bridge_index_path, storage_options=S3_STORAGE_OPTIONS)
+    return pd.read_parquet(bridge_index_path)
+
+
+def get_raster_bounds(tif_path: Path) -> Tuple[float, float, float, float]:
+    """
+    Get the bounding box of a raster file.
+
+    Args:
+        tif_path: Path to the raster file
+
+    Returns:
+        Tuple of (xmin, ymin, xmax, ymax)
+    """
+    ds = gdal.Open(str(tif_path))
+    gt = ds.GetGeoTransform()
+    width = ds.RasterXSize
+    height = ds.RasterYSize
+
+    xmin = gt[0]
+    xmax = gt[0] + width * gt[1]
+    ymax = gt[3]
+    ymin = gt[3] + height * gt[5]
+
+    ds = None
+    return (xmin, ymin, xmax, ymax)
+
+
+def boxes_intersect(box1: Tuple[float, float, float, float], box2: Dict[str, float]) -> bool:
+    """
+    Check if two bounding boxes intersect.
+
+    Args:
+        box1: Tuple of (xmin, ymin, xmax, ymax)
+        box2: Dict with keys xmin, ymin, xmax, ymax
+
+    Returns:
+        True if boxes intersect
+    """
+    return not (
+        box1[2] < box2["xmin"]  # box1 xmax < box2 xmin
+        or box1[0] > box2["xmax"]  # box1 xmin > box2 xmax
+        or box1[3] < box2["ymin"]  # box1 ymax < box2 ymin
+        or box1[1] > box2["ymax"]  # box1 ymin > box2 ymax
+    )
+
+
+def query_intersecting_bridges(
+    depth_bounds: Tuple[float, float, float, float], bridge_index: pd.DataFrame
+) -> pd.DataFrame:
+    """
+    Query the bridge index for bridges that intersect the depth raster bounds.
+
+    Args:
+        depth_bounds: Bounding box of depth raster (xmin, ymin, xmax, ymax)
+        bridge_index: DataFrame with bridge tile index
+
+    Returns:
+        DataFrame of intersecting bridges
+    """
+    mask = bridge_index["geometry_bbox"].apply(lambda bbox: boxes_intersect(depth_bounds, bbox))
+    return bridge_index[mask]
+
+
+def align_raster_to_reference(
+    src_path: str, ref_ds: gdal.Dataset, output_path: str, resampling: int = gdal.GRA_Bilinear
+) -> Optional[str]:
+    """
+    Align a source raster to match a reference raster's grid.
+
+    Args:
+        src_path: Path to source raster (can be /vsis3/ path)
+        ref_ds: Reference GDAL dataset to match
+        output_path: Path for aligned output
+        resampling: GDAL resampling algorithm
+
+    Returns:
+        Path to aligned raster or None if failed
+    """
+    ref_gt = ref_ds.GetGeoTransform()
+    ref_proj = ref_ds.GetProjection()
+    ref_width = ref_ds.RasterXSize
+    ref_height = ref_ds.RasterYSize
+
+    # Calculate output bounds
+    xmin = ref_gt[0]
+    ymax = ref_gt[3]
+    xmax = xmin + ref_width * ref_gt[1]
+    ymin = ymax + ref_height * ref_gt[5]
+
+    warp_options = gdal.WarpOptions(
+        format="GTiff",
+        outputBounds=(xmin, ymin, xmax, ymax),
+        xRes=abs(ref_gt[1]),
+        yRes=abs(ref_gt[5]),
+        dstSRS=ref_proj,
+        resampleAlg=resampling,
+        creationOptions=["COMPRESS=LZW"],
+    )
+
+    try:
+        result = gdal.Warp(output_path, src_path, options=warp_options)
+        if result is None:
+            logging.error(f"Failed to warp {src_path}")
+            return None
+        result = None  # Close dataset
+        return output_path
+    except Exception as e:
+        logging.error(f"Error aligning raster {src_path}: {e}")
+        return None
+
+
+def process_depth_with_bridges(
+    depth_path: Path, dem_path: Path, bridge_paths: List[str], output_path: Path, temp_dir: Path
+) -> bool:
+    """
+    Process a single depth TIF with bridge masking.
+
+    Args:
+        depth_path: Path to input depth raster
+        dem_path: Path to DEM raster for this reach
+        bridge_paths: List of bridge raster paths (can be /vsis3/)
+        output_path: Path for output COG
+        temp_dir: Temporary directory for intermediate files
+
+    Returns:
+        True if successful
+    """
+    try:
+        # Open depth raster as reference
+        depth_ds = gdal.Open(str(depth_path))
+        if depth_ds is None:
+            logging.error(f"Failed to open depth raster: {depth_path}")
+            return False
+
+        # Read depth data
+        depth_band = depth_ds.GetRasterBand(1)
+        depth_data = depth_band.ReadAsArray().astype(np.float32)
+        depth_nodata = depth_band.GetNoDataValue()
+
+        # Align and read DEM
+        aligned_dem_path = str(temp_dir / "aligned_dem.tif")
+        if not align_raster_to_reference(str(dem_path), depth_ds, aligned_dem_path):
+            depth_ds = None
+            return False
+
+        dem_ds = gdal.Open(aligned_dem_path)
+        dem_data = dem_ds.GetRasterBand(1).ReadAsArray().astype(np.float32)
+        dem_ds = None
+
+        # Process each bridge raster
+        combined_bridge_mask = np.zeros(depth_data.shape, dtype=bool)
+        combined_bridge_elev = np.full(depth_data.shape, np.nan, dtype=np.float32)
+
+        for i, bridge_path in enumerate(bridge_paths):
+            aligned_bridge_path = str(temp_dir / f"aligned_bridge_{i}.tif")
+            if not align_raster_to_reference(bridge_path, depth_ds, aligned_bridge_path):
+                logging.warning(f"Failed to align bridge raster: {bridge_path}")
+                continue
+
+            bridge_ds = gdal.Open(aligned_bridge_path)
+            if bridge_ds is None:
+                continue
+
+            bridge_band = bridge_ds.GetRasterBand(1)
+            bridge_data = bridge_band.ReadAsArray().astype(np.float32)
+            bridge_nodata = bridge_band.GetNoDataValue()
+            bridge_ds = None
+
+            # Create mask for valid bridge pixels
+            if bridge_nodata is not None:
+                valid_bridge = ~np.isclose(bridge_data, bridge_nodata)
+            else:
+                valid_bridge = ~np.isnan(bridge_data)
+
+            # Update combined bridge data
+            combined_bridge_mask |= valid_bridge
+            np.copyto(combined_bridge_elev, bridge_data, where=valid_bridge)
+
+        # Apply bridge masking algorithm
+        if np.any(combined_bridge_mask):
+            # Calculate WSE where we have depth
+            has_depth = depth_data > 0
+            if depth_nodata is not None:
+                has_depth &= ~np.isclose(depth_data, depth_nodata)
+
+            # Only process pixels that have both bridge and depth
+            process_mask = combined_bridge_mask & has_depth
+
+            if np.any(process_mask):
+                # Calculate Water Surface Elevation
+                wse = dem_data + depth_data
+
+                # Calculate difference: WSE - bridge_elevation
+                delta = wse - combined_bridge_elev
+
+                # Apply masking rules:
+                # - If bridge > WSE (delta < 0): bridge is dry, set depth = 0
+                # - If bridge < WSE (delta > 0): bridge submerged, depth = delta
+                bridge_dry = process_mask & (delta < 0)
+                bridge_submerged = process_mask & (delta >= 0)
+
+                depth_data[bridge_dry] = 0
+                depth_data[bridge_submerged] = delta[bridge_submerged]
+
+        # Write output as COG
+        driver = gdal.GetDriverByName("GTiff")
+        temp_output = str(temp_dir / "temp_output.tif")
+
+        out_ds = driver.Create(
+            temp_output, depth_ds.RasterXSize, depth_ds.RasterYSize, 1, gdal.GDT_Float32, ["COMPRESS=LZW"]
+        )
+        out_ds.SetGeoTransform(depth_ds.GetGeoTransform())
+        out_ds.SetProjection(depth_ds.GetProjection())
+
+        out_band = out_ds.GetRasterBand(1)
+        if depth_nodata is not None:
+            out_band.SetNoDataValue(depth_nodata)
+        out_band.WriteArray(depth_data)
+        out_ds.FlushCache()
+        out_ds = None
+        depth_ds = None
+
+        # Convert to COG
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        cog_options = gdal.TranslateOptions(format="COG", creationOptions=["COMPRESS=LZW"])
+        gdal.Translate(str(output_path), temp_output, options=cog_options)
+
+        return True
+
+    except Exception as e:
+        logging.error(f"Error processing {depth_path}: {e}", exc_info=True)
+        return False
+
+
+def copy_as_cog(src_path: Path, dest_path: Path) -> bool:
+    """
+    Copy a raster file to destination as COG format.
+
+    Args:
+        src_path: Source raster path
+        dest_path: Destination path
+
+    Returns:
+        True if successful
+    """
+    try:
+        dest_path.parent.mkdir(parents=True, exist_ok=True)
+        cog_options = gdal.TranslateOptions(format="COG", creationOptions=["COMPRESS=LZW"])
+        result = gdal.Translate(str(dest_path), str(src_path), options=cog_options)
+        return result is not None
+    except Exception as e:
+        logging.error(f"Error copying {src_path} to COG: {e}")
+        return False
+
+
+def get_dem_path_for_reach(reach_id: str, submodels_dir: Path) -> Optional[Path]:
+    """
+    Get the DEM path for a specific reach from the submodels directory.
+
+    Args:
+        reach_id: The reach ID
+        submodels_dir: Path to submodels directory
+
+    Returns:
+        Path to DEM TIF or None if not found
+    """
+    terrain_dir = submodels_dir / reach_id / "Terrain"
+    if not terrain_dir.exists():
+        return None
+
+    # Look for the DEM TIF file
+    dem_files = list(terrain_dir.glob("*.seamless_3dep_dem_3m_5070.tif"))
+    if dem_files:
+        return dem_files[0]
+
+    # Fallback: look for any .tif that's not .hdf
+    tif_files = [f for f in terrain_dir.glob("*.tif") if ".hdf" not in f.name]
+    if tif_files:
+        return tif_files[0]
+
+    return None
+
+
+def bridge_worker(args: tuple) -> Tuple[str, bool]:
+    """
+    Worker function for processing a single depth TIF.
+
+    Args:
+        args: Tuple of (depth_path, dem_path, bridge_paths, output_path, temp_base_dir)
+
+    Returns:
+        Tuple of (depth_path_str, success)
+    """
+    depth_path, dem_path, bridge_paths, output_path, temp_base_dir = args
+
+    import tempfile
+
+    with tempfile.TemporaryDirectory(dir=temp_base_dir) as temp_dir:
+        temp_path = Path(temp_dir)
+
+        if bridge_paths:
+            # Process with bridge masking
+            success = process_depth_with_bridges(depth_path, dem_path, bridge_paths, output_path, temp_path)
+        else:
+            # No bridges - just copy as COG
+            success = copy_as_cog(depth_path, output_path)
+
+    return (str(depth_path), success)
+
+
+def process_bridges(collection: "CollectionData", print_progress: bool = False) -> Dict[str, any]:
+    """
+    Apply bridge masking to depth library TIFs.
+
+    This function reads the bridge tile index, processes each depth TIF
+    to adjust water depths where bridges intersect, and outputs the
+    results as Cloud Optimized GeoTIFFs.
+
+    Args:
+        collection: CollectionData object with configuration including:
+            - library_dir: Path to depth library with TIF files
+            - submodels_dir: Path to submodels with terrain data
+            - bridge_tile_index_path: S3 path to bridge index parquet
+        print_progress: Whether to display progress information
+
+    Returns:
+        Dict with processing statistics:
+            - total: Total number of TIFs processed
+            - success: Number of successful processes
+            - failed: Number of failed processes
+            - with_bridges: List of file paths that had bridges masked
+            - without_bridges: List of file paths with no bridge intersections
+    """
+    library_dir = Path(collection.library_dir)
+    submodels_dir = Path(collection.submodels_dir)
+    bridge_index_path = collection.bridge_tile_index_path
+    process_count = collection.config["execution"]["OPTIMUM_PARALLEL_PROCESS_COUNT"]
+
+    setup_gdal_environment(collection)
+
+    if print_progress:
+        print(f"Loading bridge index from: {bridge_index_path}")
+
+    # Load bridge index
+    bridge_index = load_bridge_index(bridge_index_path)
+    if print_progress:
+        print(f"Loaded {len(bridge_index)} bridge records")
+
+    # Rename library to temp
+    library_temp_dir = library_dir.parent / "library_temp"
+    if library_temp_dir.exists():
+        shutil.rmtree(library_temp_dir)
+
+    if print_progress:
+        print(f"Renaming {library_dir} to {library_temp_dir}")
+    shutil.move(str(library_dir), str(library_temp_dir))
+
+    # Create new library directory
+    library_dir.mkdir(parents=True, exist_ok=True)
+
+    # Get all depth TIFs
+    depth_tifs = list(library_temp_dir.rglob("*.tif"))
+    if print_progress:
+        print(f"Found {len(depth_tifs)} depth TIFs to process")
+
+    # Prepare worker arguments and track which files have bridges
+    worker_args = []
+    files_with_bridges = []
+    files_without_bridges = []
+    for depth_path in depth_tifs:
+        # Get reach ID from path structure: library_temp/{reach_id}/z_xxx/f_yyy.tif
+        # The reach_id is the parent of the z_xxx folder
+        reach_id = depth_path.parent.parent.name
+
+        # Get DEM path for this reach
+        dem_path = get_dem_path_for_reach(reach_id, submodels_dir)
+        if dem_path is None:
+            logging.warning(f"No DEM found for reach {reach_id}, skipping")
+            continue
+
+        # Get depth raster bounds and query for intersecting bridges
+        try:
+            depth_bounds = get_raster_bounds(depth_path)
+            intersecting_bridges = query_intersecting_bridges(depth_bounds, bridge_index)
+            bridge_paths = intersecting_bridges["location"].tolist() if len(intersecting_bridges) > 0 else []
+        except Exception as e:
+            logging.error(f"Error querying bridges for {depth_path}: {e}")
+            bridge_paths = []
+
+        # Track which files have bridges
+        if bridge_paths:
+            files_with_bridges.append(str(depth_path))
+        else:
+            files_without_bridges.append(str(depth_path))
+
+        # Calculate output path (same relative structure)
+        relative_path = depth_path.relative_to(library_temp_dir)
+        output_path = library_dir / relative_path
+
+        worker_args.append(
+            (
+                depth_path,
+                dem_path,
+                bridge_paths,
+                output_path,
+                str(library_dir.parent),  # temp base dir
+            )
+        )
+
+    # Process with multiprocessing
+    success_count = 0
+    fail_count = 0
+
+    with multiprocessing.Pool(process_count) as pool:
+        for i, (path, success) in enumerate(pool.imap_unordered(bridge_worker, worker_args), 1):
+            if success:
+                success_count += 1
+            else:
+                fail_count += 1
+                logging.error(f"Failed to process: {path}")
+
+            if print_progress:
+                sys.stdout.write(
+                    f"\rProcessing: {i}/{len(worker_args)} (success: {success_count}, failed: {fail_count})"
+                )
+                sys.stdout.flush()
+
+    if print_progress:
+        sys.stdout.write("\n")
+        print(f"Bridge processing complete: {success_count} succeeded, {fail_count} failed")
+
+    # Clean up temp directory
+    if fail_count == 0:
+        if print_progress:
+            print(f"Removing temporary directory: {library_temp_dir}")
+        shutil.rmtree(library_temp_dir)
+    else:
+        logging.warning(f"Keeping {library_temp_dir} due to {fail_count} failures")
+        if print_progress:
+            print(f"WARNING: Keeping {library_temp_dir} due to failures")
+
+    return {
+        "total": len(worker_args),
+        "success": success_count,
+        "failed": fail_count,
+        "with_bridges": files_with_bridges,
+        "without_bridges": files_without_bridges,
+    }

--- a/src/process/bridge_processor.py
+++ b/src/process/bridge_processor.py
@@ -9,10 +9,11 @@ Processing Steps:
 1. Query bridge tile index for intersecting bridges
 2. If intersection: load depth, DEM, and bridge rasters
 3. Align all rasters to depth grid
-4. Calculate WSE = DEM_elevation + depth
-5. Adjust depth based on bridge comparison:
-   - If bridge > WSE (dry): set depth = 0
-   - If bridge < WSE (submerged): set depth = WSE - bridge_elevation
+4. Convert bridge elevations from meters to feet (DEM/depth are in feet)
+5. Calculate WSE = DEM_elevation + depth (only for valid depth pixels, nodata=-9999)
+6. Adjust depth based on bridge comparison:
+   - If bridge > WSE (above water): set depth = nodata (no flooding under bridge)
+   - If bridge <= WSE (submerged): set depth = WSE - bridge_elevation (water above deck)
 """
 
 import logging
@@ -164,7 +165,7 @@ def align_raster_to_reference(
 
 def process_depth_with_bridges(
     depth_path: Path, dem_path: Path, bridge_paths: List[str], output_path: Path, temp_dir: Path
-) -> bool:
+) -> Tuple[bool, int]:
     """
     Process a single depth TIF with bridge masking.
 
@@ -176,14 +177,14 @@ def process_depth_with_bridges(
         temp_dir: Temporary directory for intermediate files
 
     Returns:
-        True if successful
+        Tuple of (success, pixels_modified)
     """
     try:
         # Open depth raster as reference
         depth_ds = gdal.Open(str(depth_path))
         if depth_ds is None:
             logging.error(f"Failed to open depth raster: {depth_path}")
-            return False
+            return (False, 0)
 
         # Read depth data
         depth_band = depth_ds.GetRasterBand(1)
@@ -194,7 +195,7 @@ def process_depth_with_bridges(
         aligned_dem_path = str(temp_dir / "aligned_dem.tif")
         if not align_raster_to_reference(str(dem_path), depth_ds, aligned_dem_path):
             depth_ds = None
-            return False
+            return (False, 0)
 
         dem_ds = gdal.Open(aligned_dem_path)
         dem_data = dem_ds.GetRasterBand(1).ReadAsArray().astype(np.float32)
@@ -219,6 +220,12 @@ def process_depth_with_bridges(
             bridge_nodata = bridge_band.GetNoDataValue()
             bridge_ds = None
 
+            # Convert bridge elevations from meters to feet
+            METERS_TO_FEET = 3.28084
+            bridge_data = bridge_data * METERS_TO_FEET
+            if bridge_nodata is not None:
+                bridge_nodata = bridge_nodata * METERS_TO_FEET
+
             # Create mask for valid bridge pixels
             if bridge_nodata is not None:
                 valid_bridge = ~np.isclose(bridge_data, bridge_nodata)
@@ -230,14 +237,16 @@ def process_depth_with_bridges(
             np.copyto(combined_bridge_elev, bridge_data, where=valid_bridge)
 
         # Apply bridge masking algorithm
+        pixels_modified = 0
         if np.any(combined_bridge_mask):
-            # Calculate WSE where we have depth
-            has_depth = depth_data > 0
+            # Calculate WSE where we have valid depth (nodata is -9999, not 0)
             if depth_nodata is not None:
-                has_depth &= ~np.isclose(depth_data, depth_nodata)
+                has_valid_depth = ~np.isclose(depth_data, depth_nodata)
+            else:
+                has_valid_depth = ~np.isnan(depth_data)
 
-            # Only process pixels that have both bridge and depth
-            process_mask = combined_bridge_mask & has_depth
+            # Only process pixels that have both bridge and valid depth
+            process_mask = combined_bridge_mask & has_valid_depth
 
             if np.any(process_mask):
                 # Calculate Water Surface Elevation
@@ -247,12 +256,18 @@ def process_depth_with_bridges(
                 delta = wse - combined_bridge_elev
 
                 # Apply masking rules:
-                # - If bridge > WSE (delta < 0): bridge is dry, set depth = 0
-                # - If bridge < WSE (delta > 0): bridge submerged, depth = delta
-                bridge_dry = process_mask & (delta < 0)
+                # - If bridge > WSE (delta < 0): bridge is above water, set depth = nodata
+                # - If bridge <= WSE (delta >= 0): bridge submerged, depth = WSE - bridge_elev
+                bridge_above_water = process_mask & (delta < 0)
                 bridge_submerged = process_mask & (delta >= 0)
 
-                depth_data[bridge_dry] = 0
+                # Track pixels that will be modified
+                pixels_modified = int(np.sum(bridge_above_water) + np.sum(bridge_submerged))
+
+                # Set nodata for pixels where bridge is above water surface
+                nodata_value = depth_nodata if depth_nodata is not None else -9999.0
+                depth_data[bridge_above_water] = nodata_value
+                # When bridge is submerged, depth is water height above the bridge deck
                 depth_data[bridge_submerged] = delta[bridge_submerged]
 
         # Write output as COG
@@ -278,11 +293,11 @@ def process_depth_with_bridges(
         cog_options = gdal.TranslateOptions(format="COG", creationOptions=["COMPRESS=LZW"])
         gdal.Translate(str(output_path), temp_output, options=cog_options)
 
-        return True
+        return (True, pixels_modified)
 
     except Exception as e:
         logging.error(f"Error processing {depth_path}: {e}", exc_info=True)
-        return False
+        return (False, 0)
 
 
 def copy_as_cog(src_path: Path, dest_path: Path) -> bool:
@@ -334,7 +349,7 @@ def get_dem_path_for_reach(reach_id: str, submodels_dir: Path) -> Optional[Path]
     return None
 
 
-def bridge_worker(args: tuple) -> Tuple[str, bool]:
+def bridge_worker(args: tuple) -> Tuple[str, bool, int]:
     """
     Worker function for processing a single depth TIF.
 
@@ -342,7 +357,7 @@ def bridge_worker(args: tuple) -> Tuple[str, bool]:
         args: Tuple of (depth_path, dem_path, bridge_paths, output_path, temp_base_dir)
 
     Returns:
-        Tuple of (depth_path_str, success)
+        Tuple of (depth_path_str, success, pixels_modified)
     """
     depth_path, dem_path, bridge_paths, output_path, temp_base_dir = args
 
@@ -353,12 +368,15 @@ def bridge_worker(args: tuple) -> Tuple[str, bool]:
 
         if bridge_paths:
             # Process with bridge masking
-            success = process_depth_with_bridges(depth_path, dem_path, bridge_paths, output_path, temp_path)
+            success, pixels_modified = process_depth_with_bridges(
+                depth_path, dem_path, bridge_paths, output_path, temp_path
+            )
         else:
             # No bridges - just copy as COG
             success = copy_as_cog(depth_path, output_path)
+            pixels_modified = 0
 
-    return (str(depth_path), success)
+    return (str(depth_path), success, pixels_modified)
 
 
 def process_bridges(collection: "CollectionData", print_progress: bool = False) -> Dict[str, any]:
@@ -381,8 +399,9 @@ def process_bridges(collection: "CollectionData", print_progress: bool = False) 
             - total: Total number of TIFs processed
             - success: Number of successful processes
             - failed: Number of failed processes
-            - with_bridges: List of file paths that had bridges masked
+            - with_bridges: List of file paths that had bridge intersections
             - without_bridges: List of file paths with no bridge intersections
+            - modified: List of file paths where depth values were actually modified
     """
     library_dir = Path(collection.library_dir)
     submodels_dir = Path(collection.submodels_dir)
@@ -463,11 +482,14 @@ def process_bridges(collection: "CollectionData", print_progress: bool = False) 
     # Process with multiprocessing
     success_count = 0
     fail_count = 0
+    files_modified = []
 
     with multiprocessing.Pool(process_count) as pool:
-        for i, (path, success) in enumerate(pool.imap_unordered(bridge_worker, worker_args), 1):
+        for i, (path, success, pixels_modified) in enumerate(pool.imap_unordered(bridge_worker, worker_args), 1):
             if success:
                 success_count += 1
+                if pixels_modified > 0:
+                    files_modified.append(path)
             else:
                 fail_count += 1
                 logging.error(f"Failed to process: {path}")
@@ -498,4 +520,5 @@ def process_bridges(collection: "CollectionData", print_progress: bool = False) 
         "failed": fail_count,
         "with_bridges": files_with_bridges,
         "without_bridges": files_without_bridges,
+        "modified": files_modified,
     }

--- a/src/process/bridge_processor.py
+++ b/src/process/bridge_processor.py
@@ -3,17 +3,7 @@ Bridge processor module for masking depth library TIFs based on bridge locations
 
 This module processes depth grids to adjust water depth values where bridges
 are located. The algorithm calculates Water Surface Elevation (WSE) and compares
-it to bridge deck elevations to determine if water flows over or under bridges.
-
-Processing Steps:
-1. Query bridge tile index for intersecting bridges
-2. If intersection: load depth, DEM, and bridge rasters
-3. Align all rasters to depth grid
-4. Convert bridge elevations from meters to feet (DEM/depth are in feet)
-5. Calculate WSE = DEM_elevation + depth (only for valid depth pixels, nodata=-9999)
-6. Adjust depth based on bridge comparison:
-   - If bridge > WSE (above water): set depth = nodata (no flooding under bridge)
-   - If bridge <= WSE (submerged): set depth = WSE - bridge_elevation (water above deck)
+it to bridge elevations to determine if bridges are submerged or not.
 """
 
 import logging
@@ -21,12 +11,14 @@ import multiprocessing
 import os
 import shutil
 import sys
+import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
 import numpy as np
 import pandas as pd
 from osgeo import gdal
+from shapely.geometry import box
 
 from .extent_library import setup_gdal_environment
 
@@ -36,31 +28,10 @@ if TYPE_CHECKING:
 # Enable GDAL exceptions
 gdal.UseExceptions()
 
-# S3 storage options for pandas
-S3_STORAGE_OPTIONS = {"profile": "fimbucket"}
-
-
-def load_bridge_index(bridge_index_path: str) -> pd.DataFrame:
-    """
-    Load the bridge tile index from S3 or local path.
-
-    Args:
-        bridge_index_path: Path to bridge index parquet (S3 or local)
-
-    Returns:
-        DataFrame with bridge index data
-    """
-    if bridge_index_path.startswith("s3://"):
-        return pd.read_parquet(bridge_index_path, storage_options=S3_STORAGE_OPTIONS)
-    return pd.read_parquet(bridge_index_path)
-
 
 def get_raster_bounds(tif_path: Path) -> Tuple[float, float, float, float]:
     """
     Get the bounding box of a raster file.
-
-    Args:
-        tif_path: Path to the raster file
 
     Returns:
         Tuple of (xmin, ymin, xmax, ymax)
@@ -77,42 +48,6 @@ def get_raster_bounds(tif_path: Path) -> Tuple[float, float, float, float]:
 
     ds = None
     return (xmin, ymin, xmax, ymax)
-
-
-def boxes_intersect(box1: Tuple[float, float, float, float], box2: Dict[str, float]) -> bool:
-    """
-    Check if two bounding boxes intersect.
-
-    Args:
-        box1: Tuple of (xmin, ymin, xmax, ymax)
-        box2: Dict with keys xmin, ymin, xmax, ymax
-
-    Returns:
-        True if boxes intersect
-    """
-    return not (
-        box1[2] < box2["xmin"]  # box1 xmax < box2 xmin
-        or box1[0] > box2["xmax"]  # box1 xmin > box2 xmax
-        or box1[3] < box2["ymin"]  # box1 ymax < box2 ymin
-        or box1[1] > box2["ymax"]  # box1 ymin > box2 ymax
-    )
-
-
-def query_intersecting_bridges(
-    depth_bounds: Tuple[float, float, float, float], bridge_index: pd.DataFrame
-) -> pd.DataFrame:
-    """
-    Query the bridge index for bridges that intersect the depth raster bounds.
-
-    Args:
-        depth_bounds: Bounding box of depth raster (xmin, ymin, xmax, ymax)
-        bridge_index: DataFrame with bridge tile index
-
-    Returns:
-        DataFrame of intersecting bridges
-    """
-    mask = bridge_index["geometry_bbox"].apply(lambda bbox: boxes_intersect(depth_bounds, bbox))
-    return bridge_index[mask]
 
 
 def align_raster_to_reference(
@@ -163,8 +98,13 @@ def align_raster_to_reference(
         return None
 
 
-def process_depth_with_bridges(
-    depth_path: Path, dem_path: Path, bridge_paths: List[str], output_path: Path, temp_dir: Path
+def apply_bridge_mask(
+    depth_path: Path,
+    dem_path: Path,
+    bridge_paths: List[str],
+    output_path: Path,
+    temp_dir: Path,
+    bridge_elev_conv_factor: float,
 ) -> Tuple[bool, int]:
     """
     Process a single depth TIF with bridge masking.
@@ -175,23 +115,22 @@ def process_depth_with_bridges(
         bridge_paths: List of bridge raster paths (can be /vsis3/)
         output_path: Path for output COG
         temp_dir: Temporary directory for intermediate files
+        bridge_elev_conv_factor: Conversion factor for bridge elevations to depth grid units
 
     Returns:
         Tuple of (success, pixels_modified)
     """
     try:
-        # Open depth raster as reference
+        # Using depth raster as reference
         depth_ds = gdal.Open(str(depth_path))
         if depth_ds is None:
             logging.error(f"Failed to open depth raster: {depth_path}")
             return (False, 0)
 
-        # Read depth data
         depth_band = depth_ds.GetRasterBand(1)
         depth_data = depth_band.ReadAsArray().astype(np.float32)
         depth_nodata = depth_band.GetNoDataValue()
 
-        # Align and read DEM
         aligned_dem_path = str(temp_dir / "aligned_dem.tif")
         if not align_raster_to_reference(str(dem_path), depth_ds, aligned_dem_path):
             depth_ds = None
@@ -201,7 +140,6 @@ def process_depth_with_bridges(
         dem_data = dem_ds.GetRasterBand(1).ReadAsArray().astype(np.float32)
         dem_ds = None
 
-        # Process each bridge raster
         combined_bridge_mask = np.zeros(depth_data.shape, dtype=bool)
         combined_bridge_elev = np.full(depth_data.shape, np.nan, dtype=np.float32)
 
@@ -220,57 +158,38 @@ def process_depth_with_bridges(
             bridge_nodata = bridge_band.GetNoDataValue()
             bridge_ds = None
 
-            # Convert bridge elevations from meters to feet
-            METERS_TO_FEET = 3.28084
-            bridge_data = bridge_data * METERS_TO_FEET
-            if bridge_nodata is not None:
-                bridge_nodata = bridge_nodata * METERS_TO_FEET
+            valid_bridge = bridge_data != bridge_nodata
 
-            # Create mask for valid bridge pixels
-            if bridge_nodata is not None:
-                valid_bridge = ~np.isclose(bridge_data, bridge_nodata)
-            else:
-                valid_bridge = ~np.isnan(bridge_data)
+            # Convert bridge elevations to depth grid units
+            bridge_data = bridge_data * bridge_elev_conv_factor
 
             # Update combined bridge data
             combined_bridge_mask |= valid_bridge
             np.copyto(combined_bridge_elev, bridge_data, where=valid_bridge)
 
-        # Apply bridge masking algorithm
+        # bridge masking algorithm
         pixels_modified = 0
         if np.any(combined_bridge_mask):
-            # Calculate WSE where we have valid depth (nodata is -9999, not 0)
-            if depth_nodata is not None:
-                has_valid_depth = ~np.isclose(depth_data, depth_nodata)
-            else:
-                has_valid_depth = ~np.isnan(depth_data)
-
-            # Only process pixels that have both bridge and valid depth
+            # Only Calculate WSE where we have valid depth
+            has_valid_depth = depth_data != depth_nodata
             process_mask = combined_bridge_mask & has_valid_depth
 
             if np.any(process_mask):
-                # Calculate Water Surface Elevation
                 wse = dem_data + depth_data
-
-                # Calculate difference: WSE - bridge_elevation
                 delta = wse - combined_bridge_elev
 
-                # Apply masking rules:
                 # - If bridge > WSE (delta < 0): bridge is above water, set depth = nodata
                 # - If bridge <= WSE (delta >= 0): bridge submerged, depth = WSE - bridge_elev
                 bridge_above_water = process_mask & (delta < 0)
                 bridge_submerged = process_mask & (delta >= 0)
 
-                # Track pixels that will be modified
                 pixels_modified = int(np.sum(bridge_above_water) + np.sum(bridge_submerged))
 
-                # Set nodata for pixels where bridge is above water surface
                 nodata_value = depth_nodata if depth_nodata is not None else -9999.0
                 depth_data[bridge_above_water] = nodata_value
                 # When bridge is submerged, depth is water height above the bridge deck
                 depth_data[bridge_submerged] = delta[bridge_submerged]
 
-        # Write output as COG
         driver = gdal.GetDriverByName("GTiff")
         temp_output = str(temp_dir / "temp_output.tif")
 
@@ -288,7 +207,6 @@ def process_depth_with_bridges(
         out_ds = None
         depth_ds = None
 
-        # Convert to COG
         output_path.parent.mkdir(parents=True, exist_ok=True)
         cog_options = gdal.TranslateOptions(format="COG", creationOptions=["COMPRESS=LZW"])
         gdal.Translate(str(output_path), temp_output, options=cog_options)
@@ -300,80 +218,31 @@ def process_depth_with_bridges(
         return (False, 0)
 
 
-def copy_as_cog(src_path: Path, dest_path: Path) -> bool:
-    """
-    Copy a raster file to destination as COG format.
-
-    Args:
-        src_path: Source raster path
-        dest_path: Destination path
-
-    Returns:
-        True if successful
-    """
-    try:
-        dest_path.parent.mkdir(parents=True, exist_ok=True)
-        cog_options = gdal.TranslateOptions(format="COG", creationOptions=["COMPRESS=LZW"])
-        result = gdal.Translate(str(dest_path), str(src_path), options=cog_options)
-        return result is not None
-    except Exception as e:
-        logging.error(f"Error copying {src_path} to COG: {e}")
-        return False
-
-
-def get_dem_path_for_reach(reach_id: str, submodels_dir: Path) -> Optional[Path]:
-    """
-    Get the DEM path for a specific reach from the submodels directory.
-
-    Args:
-        reach_id: The reach ID
-        submodels_dir: Path to submodels directory
-
-    Returns:
-        Path to DEM TIF or None if not found
-    """
-    terrain_dir = submodels_dir / reach_id / "Terrain"
-    if not terrain_dir.exists():
-        return None
-
-    # Look for the DEM TIF file
-    dem_files = list(terrain_dir.glob("*.seamless_3dep_dem_3m_5070.tif"))
-    if dem_files:
-        return dem_files[0]
-
-    # Fallback: look for any .tif that's not .hdf
-    tif_files = [f for f in terrain_dir.glob("*.tif") if ".hdf" not in f.name]
-    if tif_files:
-        return tif_files[0]
-
-    return None
-
-
 def bridge_worker(args: tuple) -> Tuple[str, bool, int]:
     """
     Worker function for processing a single depth TIF.
 
     Args:
-        args: Tuple of (depth_path, dem_path, bridge_paths, output_path, temp_base_dir)
+        args: Tuple of (depth_path, dem_path, bridge_paths, output_path, temp_base_dir, bridge_elev_conv_factor)
 
     Returns:
         Tuple of (depth_path_str, success, pixels_modified)
     """
-    depth_path, dem_path, bridge_paths, output_path, temp_base_dir = args
-
-    import tempfile
+    depth_path, dem_path, bridge_paths, output_path, temp_base_dir, bridge_elev_conv_factor = args
 
     with tempfile.TemporaryDirectory(dir=temp_base_dir) as temp_dir:
         temp_path = Path(temp_dir)
 
         if bridge_paths:
-            # Process with bridge masking
-            success, pixels_modified = process_depth_with_bridges(
-                depth_path, dem_path, bridge_paths, output_path, temp_path
+            success, pixels_modified = apply_bridge_mask(
+                depth_path, dem_path, bridge_paths, output_path, temp_path, bridge_elev_conv_factor
             )
         else:
-            # No bridges - just copy as COG
-            success = copy_as_cog(depth_path, output_path)
+            # No bridges so just copy as COG
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            cog_options = gdal.TranslateOptions(format="COG", creationOptions=["COMPRESS=LZW"])
+            result = gdal.Translate(str(output_path), str(depth_path), options=cog_options)
+            success = result is not None
             pixels_modified = 0
 
     return (str(depth_path), success, pixels_modified)
@@ -407,35 +276,31 @@ def process_bridges(collection: "CollectionData", print_progress: bool = False) 
     submodels_dir = Path(collection.submodels_dir)
     bridge_index_path = collection.bridge_tile_index_path
     process_count = collection.config["execution"]["OPTIMUM_PARALLEL_PROCESS_COUNT"]
+    bridge_elev_conv_factor = collection.config["bridge_processing"]["BRIDGE_ELEV_CONV_FACTOR"]
 
     setup_gdal_environment(collection)
 
     if print_progress:
-        print(f"Loading bridge index from: {bridge_index_path}")
+        sys.stdout.write(f"Loading bridge index from: {bridge_index_path}\n")
 
-    # Load bridge index
-    bridge_index = load_bridge_index(bridge_index_path)
+    bridge_index = pd.read_parquet(bridge_index_path)
     if print_progress:
-        print(f"Loaded {len(bridge_index)} bridge records")
+        sys.stdout.write(f"Loaded {len(bridge_index)} bridge records\n")
 
-    # Rename library to temp
     library_temp_dir = library_dir.parent / "library_temp"
     if library_temp_dir.exists():
         shutil.rmtree(library_temp_dir)
 
     if print_progress:
-        print(f"Renaming {library_dir} to {library_temp_dir}")
+        sys.stdout.write(f"Renaming {library_dir} to {library_temp_dir}\n")
     shutil.move(str(library_dir), str(library_temp_dir))
 
-    # Create new library directory
     library_dir.mkdir(parents=True, exist_ok=True)
 
-    # Get all depth TIFs
     depth_tifs = list(library_temp_dir.rglob("*.tif"))
     if print_progress:
-        print(f"Found {len(depth_tifs)} depth TIFs to process")
+        sys.stdout.write(f"Found {len(depth_tifs)} depth TIFs to process\n")
 
-    # Prepare worker arguments and track which files have bridges
     worker_args = []
     files_with_bridges = []
     files_without_bridges = []
@@ -444,28 +309,28 @@ def process_bridges(collection: "CollectionData", print_progress: bool = False) 
         # The reach_id is the parent of the z_xxx folder
         reach_id = depth_path.parent.parent.name
 
-        # Get DEM path for this reach
-        dem_path = get_dem_path_for_reach(reach_id, submodels_dir)
-        if dem_path is None:
-            logging.warning(f"No DEM found for reach {reach_id}, skipping")
-            continue
+        terrain_dir = submodels_dir / reach_id / "Terrain"
+        dem_files = list(terrain_dir.glob("*.seamless_3dep_dem_3m_5070.tif"))
+        if not dem_files:
+            raise FileNotFoundError(f"No DEM found for reach {reach_id} in {terrain_dir}")
+        dem_path = dem_files[0]
 
-        # Get depth raster bounds and query for intersecting bridges
         try:
             depth_bounds = get_raster_bounds(depth_path)
-            intersecting_bridges = query_intersecting_bridges(depth_bounds, bridge_index)
-            bridge_paths = intersecting_bridges["location"].tolist() if len(intersecting_bridges) > 0 else []
+            raster_box = box(*depth_bounds)
+            mask = bridge_index["geometry_bbox"].apply(
+                lambda bbox: raster_box.intersects(box(bbox["xmin"], bbox["ymin"], bbox["xmax"], bbox["ymax"]))
+            )
+            bridge_paths = bridge_index[mask]["location"].tolist()
         except Exception as e:
             logging.error(f"Error querying bridges for {depth_path}: {e}")
             bridge_paths = []
 
-        # Track which files have bridges
         if bridge_paths:
             files_with_bridges.append(str(depth_path))
         else:
             files_without_bridges.append(str(depth_path))
 
-        # Calculate output path (same relative structure)
         relative_path = depth_path.relative_to(library_temp_dir)
         output_path = library_dir / relative_path
 
@@ -476,10 +341,10 @@ def process_bridges(collection: "CollectionData", print_progress: bool = False) 
                 bridge_paths,
                 output_path,
                 str(library_dir.parent),  # temp base dir
+                bridge_elev_conv_factor,
             )
         )
 
-    # Process with multiprocessing
     success_count = 0
     fail_count = 0
     files_modified = []
@@ -502,17 +367,16 @@ def process_bridges(collection: "CollectionData", print_progress: bool = False) 
 
     if print_progress:
         sys.stdout.write("\n")
-        print(f"Bridge processing complete: {success_count} succeeded, {fail_count} failed")
+        sys.stdout.write(f"Bridge processing complete: {success_count} succeeded, {fail_count} failed\n")
 
-    # Clean up temp directory
     if fail_count == 0:
         if print_progress:
-            print(f"Removing temporary directory: {library_temp_dir}")
+            sys.stdout.write(f"Removing temporary directory: {library_temp_dir}\n")
         shutil.rmtree(library_temp_dir)
     else:
         logging.warning(f"Keeping {library_temp_dir} due to {fail_count} failures")
         if print_progress:
-            print(f"WARNING: Keeping {library_temp_dir} due to failures")
+            sys.stdout.write(f"WARNING: Keeping {library_temp_dir} due to failures\n")
 
     return {
         "total": len(worker_args),

--- a/src/process/bridge_processor.py
+++ b/src/process/bridge_processor.py
@@ -47,8 +47,12 @@ def align_raster(
     bounds: Tuple[float, float, float, float],
     res: Tuple[float, float],
     nodata: float = None,
+    target_crs: str = None,
 ) -> None:
-    """Align a raster to the specified extent and resolution, outputting a VRT."""
+    """Align a raster to the specified extent and resolution, outputting a VRT.
+
+    If target_crs is provided, the source raster will be reprojected to that CRS.
+    """
     xmin, ymin, xmax, ymax = bounds
     xres, yres = res
     cmd = [
@@ -67,6 +71,8 @@ def align_raster(
         "-r",
         "bilinear",
     ]
+    if target_crs is not None:
+        cmd.extend(["-t_srs", target_crs])
     if nodata is not None:
         cmd.extend(["-dstnodata", nodata])
     cmd.extend([src_path, output_path])
@@ -205,11 +211,14 @@ def process_bridges(collection: "CollectionData", print_progress: bool = False) 
             bridges_vrt = reach_temp_dir / "bridges.vrt"
             run_cmd(["gdalbuildvrt", bridges_vrt] + bridge_paths, "gdalbuildvrt")
 
+            # Depth rasters are in EPSG:5070, reproject DEM and bridges to match
+            target_crs = "EPSG:5070"
+
             aligned_dem = reach_temp_dir / "aligned_dem.vrt"
-            align_raster(dem_path, aligned_dem, bounds, depth_res)
+            align_raster(dem_path, aligned_dem, bounds, depth_res, nodata=depth_nodata, target_crs=target_crs)
 
             aligned_bridges = reach_temp_dir / "aligned_bridges.vrt"
-            align_raster(bridges_vrt, aligned_bridges, bounds, depth_res, nodata=-9999)
+            align_raster(bridges_vrt, aligned_bridges, bounds, depth_res, nodata=depth_nodata, target_crs=target_crs)
 
             worker_args = [
                 (

--- a/src/process/bridge_processor.py
+++ b/src/process/bridge_processor.py
@@ -13,7 +13,7 @@ import shutil
 import sys
 import tempfile
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 import pandas as pd
@@ -22,76 +22,38 @@ from shapely.geometry import box
 
 from .extent_library import setup_gdal_environment
 
-if TYPE_CHECKING:
-    from ..setup.collection_data import CollectionData
-
 # Enable GDAL exceptions
 gdal.UseExceptions()
 
 
 def get_raster_bounds(tif_path: Path) -> Tuple[float, float, float, float]:
-    """
-    Get the bounding box of a raster file.
-
-    Returns:
-        Tuple of (xmin, ymin, xmax, ymax)
-    """
+    """Get bounding box (xmin, ymin, xmax, ymax) of a raster file."""
     ds = gdal.Open(str(tif_path))
-    gt = ds.GetGeoTransform()
-    width = ds.RasterXSize
-    height = ds.RasterYSize
-
-    xmin = gt[0]
-    xmax = gt[0] + width * gt[1]
-    ymax = gt[3]
-    ymin = gt[3] + height * gt[5]
-
+    gt, w, h = ds.GetGeoTransform(), ds.RasterXSize, ds.RasterYSize
     ds = None
-    return (xmin, ymin, xmax, ymax)
+    return gt[0], gt[3] + h * gt[5], gt[0] + w * gt[1], gt[3]
 
 
 def align_raster_to_reference(
     src_path: str, ref_ds: gdal.Dataset, output_path: str, resampling: int = gdal.GRA_Bilinear
 ) -> Optional[str]:
-    """
-    Align a source raster to match a reference raster's grid.
-
-    Args:
-        src_path: Path to source raster (can be /vsis3/ path)
-        ref_ds: Reference GDAL dataset to match
-        output_path: Path for aligned output
-        resampling: GDAL resampling algorithm
-
-    Returns:
-        Path to aligned raster or None if failed
-    """
-    ref_gt = ref_ds.GetGeoTransform()
-    ref_proj = ref_ds.GetProjection()
-    ref_width = ref_ds.RasterXSize
-    ref_height = ref_ds.RasterYSize
-
-    # Calculate output bounds
-    xmin = ref_gt[0]
-    ymax = ref_gt[3]
-    xmax = xmin + ref_width * ref_gt[1]
-    ymin = ymax + ref_height * ref_gt[5]
-
+    """Align a source raster to match a reference raster's grid."""
+    gt, w, h = ref_ds.GetGeoTransform(), ref_ds.RasterXSize, ref_ds.RasterYSize
     warp_options = gdal.WarpOptions(
         format="GTiff",
-        outputBounds=(xmin, ymin, xmax, ymax),
-        xRes=abs(ref_gt[1]),
-        yRes=abs(ref_gt[5]),
-        dstSRS=ref_proj,
+        outputBounds=(gt[0], gt[3] + h * gt[5], gt[0] + w * gt[1], gt[3]),
+        xRes=abs(gt[1]),
+        yRes=abs(gt[5]),
+        dstSRS=ref_ds.GetProjection(),
         resampleAlg=resampling,
         creationOptions=["COMPRESS=LZW"],
     )
-
     try:
         result = gdal.Warp(output_path, src_path, options=warp_options)
         if result is None:
             logging.error(f"Failed to warp {src_path}")
             return None
-        result = None  # Close dataset
+        result = None
         return output_path
     except Exception as e:
         logging.error(f"Error aligning raster {src_path}: {e}")
@@ -106,99 +68,60 @@ def apply_bridge_mask(
     temp_dir: Path,
     bridge_elev_conv_factor: float,
 ) -> Tuple[bool, int]:
-    """
-    Process a single depth TIF with bridge masking.
-
-    Args:
-        depth_path: Path to input depth raster
-        dem_path: Path to DEM raster for this reach
-        bridge_paths: List of bridge raster paths (can be /vsis3/)
-        output_path: Path for output COG
-        temp_dir: Temporary directory for intermediate files
-        bridge_elev_conv_factor: Conversion factor for bridge elevations to depth grid units
-
-    Returns:
-        Tuple of (success, pixels_modified)
-    """
+    """Process a single depth TIF with bridge masking. Returns (success, pixels_modified)."""
     try:
-        # Using depth raster as reference
         depth_ds = gdal.Open(str(depth_path))
         if depth_ds is None:
             logging.error(f"Failed to open depth raster: {depth_path}")
-            return (False, 0)
+            return False, 0
 
         depth_band = depth_ds.GetRasterBand(1)
         depth_data = depth_band.ReadAsArray().astype(np.float32)
         depth_nodata = depth_band.GetNoDataValue()
 
-        aligned_dem_path = str(temp_dir / "aligned_dem.tif")
-        if not align_raster_to_reference(str(dem_path), depth_ds, aligned_dem_path):
+        if not align_raster_to_reference(str(dem_path), depth_ds, str(temp_dir / "aligned_dem.tif")):
             depth_ds = None
-            return (False, 0)
+            return False, 0
 
-        dem_ds = gdal.Open(aligned_dem_path)
+        dem_ds = gdal.Open(str(temp_dir / "aligned_dem.tif"))
         dem_data = dem_ds.GetRasterBand(1).ReadAsArray().astype(np.float32)
         dem_ds = None
 
-        combined_bridge_mask = np.zeros(depth_data.shape, dtype=bool)
-        combined_bridge_elev = np.full(depth_data.shape, np.nan, dtype=np.float32)
+        combined_mask = np.zeros(depth_data.shape, dtype=bool)
+        combined_elev = np.full(depth_data.shape, np.nan, dtype=np.float32)
 
         for i, bridge_path in enumerate(bridge_paths):
-            aligned_bridge_path = str(temp_dir / f"aligned_bridge_{i}.tif")
-            if not align_raster_to_reference(bridge_path, depth_ds, aligned_bridge_path):
+            aligned_path = str(temp_dir / f"aligned_bridge_{i}.tif")
+            if not align_raster_to_reference(bridge_path, depth_ds, aligned_path):
                 logging.warning(f"Failed to align bridge raster: {bridge_path}")
                 continue
-
-            bridge_ds = gdal.Open(aligned_bridge_path)
+            bridge_ds = gdal.Open(aligned_path)
             if bridge_ds is None:
                 continue
-
-            bridge_band = bridge_ds.GetRasterBand(1)
-            bridge_data = bridge_band.ReadAsArray().astype(np.float32)
-            bridge_nodata = bridge_band.GetNoDataValue()
+            band = bridge_ds.GetRasterBand(1)
+            data, nodata = band.ReadAsArray().astype(np.float32), band.GetNoDataValue()
             bridge_ds = None
+            valid = data != nodata
+            combined_mask |= valid
+            np.copyto(combined_elev, data * bridge_elev_conv_factor, where=valid)
 
-            valid_bridge = bridge_data != bridge_nodata
-
-            # Convert bridge elevations to depth grid units
-            bridge_data = bridge_data * bridge_elev_conv_factor
-
-            # Update combined bridge data
-            combined_bridge_mask |= valid_bridge
-            np.copyto(combined_bridge_elev, bridge_data, where=valid_bridge)
-
-        # bridge masking algorithm
+        # Apply masking algorithm
         pixels_modified = 0
-        if np.any(combined_bridge_mask):
-            # Only Calculate WSE where we have valid depth
-            has_valid_depth = depth_data != depth_nodata
-            process_mask = combined_bridge_mask & has_valid_depth
-
+        if np.any(combined_mask):
+            process_mask = combined_mask & (depth_data != depth_nodata)
             if np.any(process_mask):
-                wse = dem_data + depth_data
-                delta = wse - combined_bridge_elev
+                delta = (dem_data + depth_data) - combined_elev
+                above_water, submerged = process_mask & (delta < 0), process_mask & (delta >= 0)
+                pixels_modified = int(np.sum(above_water) + np.sum(submerged))
+                depth_data[above_water] = depth_nodata if depth_nodata is not None else -9999.0
+                depth_data[submerged] = delta[submerged]
 
-                # - If bridge > WSE (delta < 0): bridge is above water, set depth = nodata
-                # - If bridge <= WSE (delta >= 0): bridge submerged, depth = WSE - bridge_elev
-                bridge_above_water = process_mask & (delta < 0)
-                bridge_submerged = process_mask & (delta >= 0)
-
-                pixels_modified = int(np.sum(bridge_above_water) + np.sum(bridge_submerged))
-
-                nodata_value = depth_nodata if depth_nodata is not None else -9999.0
-                depth_data[bridge_above_water] = nodata_value
-                # When bridge is submerged, depth is water height above the bridge deck
-                depth_data[bridge_submerged] = delta[bridge_submerged]
-
-        driver = gdal.GetDriverByName("GTiff")
         temp_output = str(temp_dir / "temp_output.tif")
-
-        out_ds = driver.Create(
+        out_ds = gdal.GetDriverByName("GTiff").Create(
             temp_output, depth_ds.RasterXSize, depth_ds.RasterYSize, 1, gdal.GDT_Float32, ["COMPRESS=LZW"]
         )
         out_ds.SetGeoTransform(depth_ds.GetGeoTransform())
         out_ds.SetProjection(depth_ds.GetProjection())
-
         out_band = out_ds.GetRasterBand(1)
         if depth_nodata is not None:
             out_band.SetNoDataValue(depth_nodata)
@@ -208,44 +131,33 @@ def apply_bridge_mask(
         depth_ds = None
 
         output_path.parent.mkdir(parents=True, exist_ok=True)
-        cog_options = gdal.TranslateOptions(format="COG", creationOptions=["COMPRESS=LZW"])
-        gdal.Translate(str(output_path), temp_output, options=cog_options)
-
-        return (True, pixels_modified)
+        gdal.Translate(
+            str(output_path), temp_output, options=gdal.TranslateOptions(format="COG", creationOptions=["COMPRESS=LZW"])
+        )
+        return True, pixels_modified
 
     except Exception as e:
         logging.error(f"Error processing {depth_path}: {e}", exc_info=True)
-        return (False, 0)
+        return False, 0
 
 
 def bridge_worker(args: tuple) -> Tuple[str, bool, int]:
-    """
-    Worker function for processing a single depth TIF.
-
-    Args:
-        args: Tuple of (depth_path, dem_path, bridge_paths, output_path, temp_base_dir, bridge_elev_conv_factor)
-
-    Returns:
-        Tuple of (depth_path_str, success, pixels_modified)
-    """
+    """Worker for processing a single depth TIF. Returns (path, success, pixels_modified)."""
     depth_path, dem_path, bridge_paths, output_path, temp_base_dir, bridge_elev_conv_factor = args
-
     with tempfile.TemporaryDirectory(dir=temp_base_dir) as temp_dir:
-        temp_path = Path(temp_dir)
-
         if bridge_paths:
             success, pixels_modified = apply_bridge_mask(
-                depth_path, dem_path, bridge_paths, output_path, temp_path, bridge_elev_conv_factor
+                depth_path, dem_path, bridge_paths, output_path, Path(temp_dir), bridge_elev_conv_factor
             )
         else:
-            # No bridges so just copy as COG
             output_path.parent.mkdir(parents=True, exist_ok=True)
-            cog_options = gdal.TranslateOptions(format="COG", creationOptions=["COMPRESS=LZW"])
-            result = gdal.Translate(str(output_path), str(depth_path), options=cog_options)
-            success = result is not None
-            pixels_modified = 0
-
-    return (str(depth_path), success, pixels_modified)
+            result = gdal.Translate(
+                str(output_path),
+                str(depth_path),
+                options=gdal.TranslateOptions(format="COG", creationOptions=["COMPRESS=LZW"]),
+            )
+            success, pixels_modified = result is not None, 0
+    return str(depth_path), success, pixels_modified
 
 
 def process_bridges(collection: "CollectionData", print_progress: bool = False) -> Dict[str, any]:
@@ -277,47 +189,32 @@ def process_bridges(collection: "CollectionData", print_progress: bool = False) 
     bridge_index_path = collection.bridge_tile_index_path
     process_count = collection.config["execution"]["OPTIMUM_PARALLEL_PROCESS_COUNT"]
     bridge_elev_conv_factor = collection.config["bridge_processing"]["BRIDGE_ELEV_CONV_FACTOR"]
+    _log = lambda m: print_progress and sys.stdout.write(m)
 
     setup_gdal_environment(collection)
 
-    if print_progress:
-        sys.stdout.write(f"Loading bridge index from: {bridge_index_path}\n")
-
+    _log(f"Loading bridge index from: {bridge_index_path}\n")
     bridge_index = pd.read_parquet(bridge_index_path)
-    if print_progress:
-        sys.stdout.write(f"Loaded {len(bridge_index)} bridge records\n")
+    _log(f"Loaded {len(bridge_index)} bridge records\n")
 
     library_temp_dir = library_dir.parent / "library_temp"
     if library_temp_dir.exists():
         shutil.rmtree(library_temp_dir)
-
-    if print_progress:
-        sys.stdout.write(f"Renaming {library_dir} to {library_temp_dir}\n")
+    _log(f"Renaming {library_dir} to {library_temp_dir}\n")
     shutil.move(str(library_dir), str(library_temp_dir))
-
     library_dir.mkdir(parents=True, exist_ok=True)
 
     depth_tifs = list(library_temp_dir.rglob("*.tif"))
-    if print_progress:
-        sys.stdout.write(f"Found {len(depth_tifs)} depth TIFs to process\n")
+    _log(f"Found {len(depth_tifs)} depth TIFs to process\n")
 
-    worker_args = []
-    files_with_bridges = []
-    files_without_bridges = []
+    worker_args, files_with_bridges, files_without_bridges = [], [], []
     for depth_path in depth_tifs:
-        # Get reach ID from path structure: library_temp/{reach_id}/z_xxx/f_yyy.tif
-        # The reach_id is the parent of the z_xxx folder
         reach_id = depth_path.parent.parent.name
-
-        terrain_dir = submodels_dir / reach_id / "Terrain"
-        dem_files = list(terrain_dir.glob("*.seamless_3dep_dem_3m_5070.tif"))
+        dem_files = list((submodels_dir / reach_id / "Terrain").glob("*.seamless_3dep_dem_3m_5070.tif"))
         if not dem_files:
-            raise FileNotFoundError(f"No DEM found for reach {reach_id} in {terrain_dir}")
-        dem_path = dem_files[0]
-
+            raise FileNotFoundError(f"No DEM found for reach {reach_id}")
         try:
-            depth_bounds = get_raster_bounds(depth_path)
-            raster_box = box(*depth_bounds)
+            raster_box = box(*get_raster_bounds(depth_path))
             mask = bridge_index["geometry_bbox"].apply(
                 lambda bbox: raster_box.intersects(box(bbox["xmin"], bbox["ymin"], bbox["xmax"], bbox["ymax"]))
             )
@@ -326,29 +223,19 @@ def process_bridges(collection: "CollectionData", print_progress: bool = False) 
             logging.error(f"Error querying bridges for {depth_path}: {e}")
             bridge_paths = []
 
-        if bridge_paths:
-            files_with_bridges.append(str(depth_path))
-        else:
-            files_without_bridges.append(str(depth_path))
-
-        relative_path = depth_path.relative_to(library_temp_dir)
-        output_path = library_dir / relative_path
-
+        (files_with_bridges if bridge_paths else files_without_bridges).append(str(depth_path))
         worker_args.append(
             (
                 depth_path,
-                dem_path,
+                dem_files[0],
                 bridge_paths,
-                output_path,
-                str(library_dir.parent),  # temp base dir
+                library_dir / depth_path.relative_to(library_temp_dir),
+                str(library_dir.parent),
                 bridge_elev_conv_factor,
             )
         )
 
-    success_count = 0
-    fail_count = 0
-    files_modified = []
-
+    success_count, fail_count, files_modified = 0, 0, []
     with multiprocessing.Pool(process_count) as pool:
         for i, (path, success, pixels_modified) in enumerate(pool.imap_unordered(bridge_worker, worker_args), 1):
             if success:
@@ -358,25 +245,16 @@ def process_bridges(collection: "CollectionData", print_progress: bool = False) 
             else:
                 fail_count += 1
                 logging.error(f"Failed to process: {path}")
+            _log(f"\rProcessing: {i}/{len(worker_args)} (success: {success_count}, failed: {fail_count})")
+            print_progress and sys.stdout.flush()
 
-            if print_progress:
-                sys.stdout.write(
-                    f"\rProcessing: {i}/{len(worker_args)} (success: {success_count}, failed: {fail_count})"
-                )
-                sys.stdout.flush()
-
-    if print_progress:
-        sys.stdout.write("\n")
-        sys.stdout.write(f"Bridge processing complete: {success_count} succeeded, {fail_count} failed\n")
-
+    _log(f"\nBridge processing complete: {success_count} succeeded, {fail_count} failed\n")
     if fail_count == 0:
-        if print_progress:
-            sys.stdout.write(f"Removing temporary directory: {library_temp_dir}\n")
+        _log(f"Removing temporary directory: {library_temp_dir}\n")
         shutil.rmtree(library_temp_dir)
     else:
         logging.warning(f"Keeping {library_temp_dir} due to {fail_count} failures")
-        if print_progress:
-            sys.stdout.write(f"WARNING: Keeping {library_temp_dir} due to failures\n")
+        _log(f"WARNING: Keeping {library_temp_dir} due to failures\n")
 
     return {
         "total": len(worker_args),

--- a/src/process/conflate_step_processor.py
+++ b/src/process/conflate_step_processor.py
@@ -26,7 +26,7 @@ class ConflateModelStepProcessor(BaseModelStepProcessor):
 
     def _execute_single_request(self, model: Model) -> JobRecord:
         """Single request implementation with retries"""
-        url = f"{self.collection.RIPPLE1D_API_URL}/processes/{self.collection.config["processing_steps"][self.process_name]["api_process_name"]}/execution"
+        url = f"{self.collection.RIPPLE1D_API_URL}/processes/{self.collection.config['processing_steps'][self.process_name]['api_process_name']}/execution"
         template = self.collection.config["processing_steps"][self.process_name]["payload_template"]
         payload = self._format_model_payload(template, model.id, model.name)
 

--- a/src/process/generic_reach_step_processor.py
+++ b/src/process/generic_reach_step_processor.py
@@ -25,7 +25,7 @@ class GenericReachStepProcessor(BaseReachStepProcessor):
 
     def _execute_single_request(self, reach: Reach) -> Tuple:
         """Single request implementation"""
-        url = f"{self.collection.RIPPLE1D_API_URL}/processes/{self.collection.config["processing_steps"][self.process_name]["api_process_name"]}/execution"
+        url = f"{self.collection.RIPPLE1D_API_URL}/processes/{self.collection.config['processing_steps'][self.process_name]['api_process_name']}/execution"
         template = self.collection.config["processing_steps"][self.process_name]["payload_template"]
         payload = self._format_reach_payload(template, reach.id, reach.model.id, reach.model.name)
 

--- a/src/process/kwse_step_processor.py
+++ b/src/process/kwse_step_processor.py
@@ -32,7 +32,7 @@ class KWSEStepProcessor(BaseReachStepProcessor):
         if not min_elev or not max_elev:
             return JobRecord(reach, "", "not_accepted")
 
-        url = f"{self.collection.RIPPLE1D_API_URL}/processes/{self.collection.config["processing_steps"][self.process_name]["api_process_name"]}/execution"
+        url = f"{self.collection.RIPPLE1D_API_URL}/processes/{self.collection.config['processing_steps'][self.process_name]['api_process_name']}/execution"
         template = self.collection.config["processing_steps"][self.process_name]["payload_template"]
         payload = self._format_reach_payload(template, reach.id)
         payload.update({"min_elevation": min_elev, "max_elevation": max_elev})

--- a/src/setup/collection_data.py
+++ b/src/setup/collection_data.py
@@ -48,7 +48,7 @@ class CollectionData:
         self.f2f_start_file = os.path.join(self.root_dir, "start_reaches.csv")
         self.failed_jobs_report_path = os.path.join(self.root_dir, "failed_jobs_report.xlsx")
         self.timedout_jobs_report_path = os.path.join(self.root_dir, "timedout_jobs_report.xlsx")
-
+        self.bridge_tile_index_path = self.config["paths"].get("BRIDGE_TILE_INDEX_PATH", "")
 
     def create_folders(self):
         """Create folders for source models, submodels, and library."""

--- a/src/setup/stac_importer.py
+++ b/src/setup/stac_importer.py
@@ -76,7 +76,7 @@ class STACImporter:
                 os.makedirs(model_dir, exist_ok=True)
 
                 # Download GeoPackage
-                local_gpkg_path = os.path.join(model_dir, f"{data["model_name"]}.gpkg")
+                local_gpkg_path = os.path.join(model_dir, f"{data['model_name']}.gpkg")
 
                 gpkg_url = data["gpkg"]
                 bucket_name, key = gpkg_url.replace("s3://", "").split("/", 1)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# Tests package for ripple1d-pipeline

--- a/tests/test_bridge_processor.py
+++ b/tests/test_bridge_processor.py
@@ -1,100 +1,83 @@
 """
 Test script for bridge processor development.
-Downloads mock data from S3 and tests the bridge masking functionality.
+Downloads mock data from S3 and tests the bridge masking functionality on a depth library that contains rasters that intersect bridges and then runs the extent library generation process to make sure extent generation still works.
 """
 
 import subprocess
 import sys
 from pathlib import Path
 
-# Add project root to path for imports
+# Add project root to path for src directory imports
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 import yaml
 
+from src.process.bridge_processor import process_bridges
+from src.process.extent_library import create_extent_lib
 from src.setup.collection_data import CollectionData
 
-# === Configuration ===
-MOCK_DATA_DIR = Path(__file__).parent.parent / "data" / "mock"
-S3_PROFILE = "fimbucket"
-S3_COLLECTION = "s3://fimc-data/ripple/fim_100_domain/collections/mip_18060013"
-S3_BRIDGE_INDEX = "s3://fimc-data/benchmark/stac-bench-cat/assets/bridge_index.parquet"
 
+def ensure_mock_data(mock_data_dir: Path, s3_collection: str):
+    """Download mock data from S3, always overwriting existing data since local mock data could have been changed by one of the processes being tested"""
+    mock_data_dir.mkdir(parents=True, exist_ok=True)
 
-def ensure_mock_data():
-    """Download mock data from S3 if not already present."""
-    MOCK_DATA_DIR.mkdir(parents=True, exist_ok=True)
+    library_dir = mock_data_dir / "library"
+    submodels_dir = mock_data_dir / "submodels"
 
-    library_dir = MOCK_DATA_DIR / "library"
-    submodels_dir = MOCK_DATA_DIR / "submodels"
+    print("Downloading depth library from S3...")
+    subprocess.run(
+        ["aws", "s3", "cp", "--recursive", f"{s3_collection}/library/", str(library_dir)],
+        check=True,
+    )
 
-    # Download library if not present
-    if not library_dir.exists() or not any(library_dir.iterdir()):
-        print("Downloading depth library from S3...")
-        subprocess.run(
-            ["aws", "s3", "sync", f"{S3_COLLECTION}/library/", str(library_dir), "--profile", S3_PROFILE], check=True
-        )
+    print("Downloading submodels gpkg files from S3...")
+    subprocess.run(
+        [
+            "aws",
+            "s3",
+            "cp",
+            "--recursive",
+            f"{s3_collection}/submodels/",
+            str(submodels_dir),
+            "--exclude",
+            "*",
+            "--include",
+            "*.gpkg",
+        ],
+        check=True,
+    )
 
-    # Download submodels (gpkg and Terrain) if not present
-    if not submodels_dir.exists() or not any(submodels_dir.iterdir()):
-        print("Downloading submodels (gpkg files) from S3...")
-        subprocess.run(
-            [
-                "aws",
-                "s3",
-                "sync",
-                f"{S3_COLLECTION}/submodels/",
-                str(submodels_dir),
-                "--profile",
-                S3_PROFILE,
-                "--exclude",
-                "*",
-                "--include",
-                "*.gpkg",
-            ],
-            check=True,
-        )
-
-        print("Downloading submodels (Terrain directories) from S3...")
-        subprocess.run(
-            [
-                "aws",
-                "s3",
-                "sync",
-                f"{S3_COLLECTION}/submodels/",
-                str(submodels_dir),
-                "--profile",
-                S3_PROFILE,
-                "--exclude",
-                "*",
-                "--include",
-                "*/Terrain/*",
-            ],
-            check=True,
-        )
-
-    # Bridge index is read directly from S3 - no download needed
-    print(f"Mock data ready at: {MOCK_DATA_DIR}")
-    print(f"Bridge index will be read from S3: {S3_BRIDGE_INDEX}")
+    print("Downloading submodels Terrain directories from S3...")
+    subprocess.run(
+        [
+            "aws",
+            "s3",
+            "cp",
+            "--recursive",
+            f"{s3_collection}/submodels/",
+            str(submodels_dir),
+            "--exclude",
+            "*",
+            "--include",
+            "*/Terrain/*",
+        ],
+        check=True,
+    )
     return library_dir, submodels_dir
 
 
-def create_test_config():
+def create_test_config(mock_data_dir: Path):
     """Create a test config.yaml with local mock data paths."""
     config_path = Path(__file__).parent.parent / "src" / "config.yaml"
     test_config_path = Path(__file__).parent / "test_config.yaml"
 
-    # Read original config
     with open(config_path) as f:
         config = yaml.safe_load(f)
 
     # Override paths for testing
-    # Library/submodels are local, bridge index stays on S3
-    config["paths"]["COLLECTIONS_ROOT_DIR"] = str(MOCK_DATA_DIR.parent)
-    # Keep bridge index as S3 path - pandas can read directly with storage_options
-    config["paths"]["BRIDGE_TILE_INDEX_PATH"] = S3_BRIDGE_INDEX
+    config["paths"]["COLLECTIONS_ROOT_DIR"] = str(mock_data_dir.parent)
 
-    # Override GDAL paths for Linux (use system GDAL instead of Windows paths)
+    # use Linux system GDAL instead of Windows paths
     config["flows2fim"]["GDAL_BINS_PATH"] = ""
     config["flows2fim"]["GDAL_SCRIPTS_PATH"] = ""
 
@@ -105,49 +88,23 @@ def create_test_config():
     return test_config_path
 
 
-def create_mock_collection_data():
-    """
-    Create a CollectionData object configured for mock data.
+def test_bridge_processor():
+    """Main test function for bridge processor development."""
 
-    This bypasses the normal CollectionData initialization to point
-    directly at our mock data directories.
-    """
-    # Ensure mock data is downloaded (library + submodels only)
-    ensure_mock_data()
+    mock_data_dir = Path(__file__).parent.parent / "data" / "mock"
+    s3_collection = "s3://fimc-data/ripple/fim_100_domain/collections/mip_18060013"
 
-    # Create test config
-    test_config_path = create_test_config()
-
-    # Create CollectionData with mock collection ID
+    print("Setting up mock data and CollectionData...")
+    ensure_mock_data(mock_data_dir, s3_collection)
+    test_config_path = create_test_config(mock_data_dir)
     # The "mock" collection ID combined with COLLECTIONS_ROOT_DIR=data/
     # will result in root_dir=data/mock which contains our mock data
     collection = CollectionData("mock", config_file=str(test_config_path))
 
-    return collection
-
-
-def test_bridge_processor():
-    """Main test function for bridge processor development."""
-    from src.process.bridge_processor import process_bridges
-    from src.process.extent_library import create_extent_lib
-
-    print("Setting up mock data and CollectionData...")
-    collection = create_mock_collection_data()
-
-    print(f"Library dir: {collection.library_dir}")
-    print(f"Submodels dir: {collection.submodels_dir}")
-    print(f"Extent library dir: {collection.extent_library_dir}")
-    print(f"Bridge index (S3): {collection.bridge_tile_index_path}")
-
-    print("\n" + "=" * 50)
-    print("Step 1: Running bridge processor...")
-    print("=" * 50)
+    print("\nRunning bridge processor...")
     result = process_bridges(collection, print_progress=True)
 
-    # Display files that had actual depth values modified
-    print("\n" + "-" * 50)
-    print(f"Files with depth values modified: {len(result['modified'])}")
-    print("-" * 50)
+    print(f"\nFiles with depth values modified: {len(result['modified'])}\n")
     if result["modified"]:
         for f in result["modified"]:
             print(f"  {f}")
@@ -155,16 +112,12 @@ def test_bridge_processor():
         print("  (none)")
 
     print(f"\nFiles with bridge intersections: {len(result['with_bridges'])}")
-    print(f"Files without bridge intersections: {len(result['without_bridges'])}")
+    print(f"\nFiles without bridge intersections: {len(result['without_bridges'])}")
 
-    print("\n" + "=" * 50)
-    print("Step 2: Running extent library creation...")
-    print("=" * 50)
+    print("\nRunning extent library creation...")
     create_extent_lib(collection, print_progress=True)
 
-    print("\n" + "=" * 50)
-    print("All processing steps complete!")
-    print("=" * 50)
+    print("\nAll processing steps complete!\n")
 
 
 if __name__ == "__main__":

--- a/tests/test_bridge_processor.py
+++ b/tests/test_bridge_processor.py
@@ -17,7 +17,7 @@ from src.setup.collection_data import CollectionData
 # === Configuration ===
 MOCK_DATA_DIR = Path(__file__).parent.parent / "data" / "mock"
 S3_PROFILE = "fimbucket"
-S3_COLLECTION = "s3://fimc-data/ripple/fim_100_domain/collections/mip_18070202"
+S3_COLLECTION = "s3://fimc-data/ripple/fim_100_domain/collections/mip_18060013"
 S3_BRIDGE_INDEX = "s3://fimc-data/benchmark/stac-bench-cat/assets/bridge_index.parquet"
 
 
@@ -144,17 +144,18 @@ def test_bridge_processor():
     print("=" * 50)
     result = process_bridges(collection, print_progress=True)
 
-    # Display files that had bridges masked
+    # Display files that had actual depth values modified
     print("\n" + "-" * 50)
-    print(f"Files with bridges masked: {len(result['with_bridges'])}")
+    print(f"Files with depth values modified: {len(result['modified'])}")
     print("-" * 50)
-    if result["with_bridges"]:
-        for f in result["with_bridges"]:
+    if result["modified"]:
+        for f in result["modified"]:
             print(f"  {f}")
     else:
         print("  (none)")
 
-    print(f"\nFiles without bridges: {len(result['without_bridges'])}")
+    print(f"\nFiles with bridge intersections: {len(result['with_bridges'])}")
+    print(f"Files without bridge intersections: {len(result['without_bridges'])}")
 
     print("\n" + "=" * 50)
     print("Step 2: Running extent library creation...")

--- a/tests/test_bridge_processor.py
+++ b/tests/test_bridge_processor.py
@@ -1,0 +1,170 @@
+"""
+Test script for bridge processor development.
+Downloads mock data from S3 and tests the bridge masking functionality.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+# Add project root to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import yaml
+
+from src.setup.collection_data import CollectionData
+
+# === Configuration ===
+MOCK_DATA_DIR = Path(__file__).parent.parent / "data" / "mock"
+S3_PROFILE = "fimbucket"
+S3_COLLECTION = "s3://fimc-data/ripple/fim_100_domain/collections/mip_18070202"
+S3_BRIDGE_INDEX = "s3://fimc-data/benchmark/stac-bench-cat/assets/bridge_index.parquet"
+
+
+def ensure_mock_data():
+    """Download mock data from S3 if not already present."""
+    MOCK_DATA_DIR.mkdir(parents=True, exist_ok=True)
+
+    library_dir = MOCK_DATA_DIR / "library"
+    submodels_dir = MOCK_DATA_DIR / "submodels"
+
+    # Download library if not present
+    if not library_dir.exists() or not any(library_dir.iterdir()):
+        print("Downloading depth library from S3...")
+        subprocess.run(
+            ["aws", "s3", "sync", f"{S3_COLLECTION}/library/", str(library_dir), "--profile", S3_PROFILE], check=True
+        )
+
+    # Download submodels (gpkg and Terrain) if not present
+    if not submodels_dir.exists() or not any(submodels_dir.iterdir()):
+        print("Downloading submodels (gpkg files) from S3...")
+        subprocess.run(
+            [
+                "aws",
+                "s3",
+                "sync",
+                f"{S3_COLLECTION}/submodels/",
+                str(submodels_dir),
+                "--profile",
+                S3_PROFILE,
+                "--exclude",
+                "*",
+                "--include",
+                "*.gpkg",
+            ],
+            check=True,
+        )
+
+        print("Downloading submodels (Terrain directories) from S3...")
+        subprocess.run(
+            [
+                "aws",
+                "s3",
+                "sync",
+                f"{S3_COLLECTION}/submodels/",
+                str(submodels_dir),
+                "--profile",
+                S3_PROFILE,
+                "--exclude",
+                "*",
+                "--include",
+                "*/Terrain/*",
+            ],
+            check=True,
+        )
+
+    # Bridge index is read directly from S3 - no download needed
+    print(f"Mock data ready at: {MOCK_DATA_DIR}")
+    print(f"Bridge index will be read from S3: {S3_BRIDGE_INDEX}")
+    return library_dir, submodels_dir
+
+
+def create_test_config():
+    """Create a test config.yaml with local mock data paths."""
+    config_path = Path(__file__).parent.parent / "src" / "config.yaml"
+    test_config_path = Path(__file__).parent / "test_config.yaml"
+
+    # Read original config
+    with open(config_path) as f:
+        config = yaml.safe_load(f)
+
+    # Override paths for testing
+    # Library/submodels are local, bridge index stays on S3
+    config["paths"]["COLLECTIONS_ROOT_DIR"] = str(MOCK_DATA_DIR.parent)
+    # Keep bridge index as S3 path - pandas can read directly with storage_options
+    config["paths"]["BRIDGE_TILE_INDEX_PATH"] = S3_BRIDGE_INDEX
+
+    # Override GDAL paths for Linux (use system GDAL instead of Windows paths)
+    config["flows2fim"]["GDAL_BINS_PATH"] = ""
+    config["flows2fim"]["GDAL_SCRIPTS_PATH"] = ""
+
+    # Write test config
+    with open(test_config_path, "w") as f:
+        yaml.dump(config, f, default_flow_style=False)
+
+    return test_config_path
+
+
+def create_mock_collection_data():
+    """
+    Create a CollectionData object configured for mock data.
+
+    This bypasses the normal CollectionData initialization to point
+    directly at our mock data directories.
+    """
+    # Ensure mock data is downloaded (library + submodels only)
+    ensure_mock_data()
+
+    # Create test config
+    test_config_path = create_test_config()
+
+    # Create CollectionData with mock collection ID
+    # The "mock" collection ID combined with COLLECTIONS_ROOT_DIR=data/
+    # will result in root_dir=data/mock which contains our mock data
+    collection = CollectionData("mock", config_file=str(test_config_path))
+
+    return collection
+
+
+def test_bridge_processor():
+    """Main test function for bridge processor development."""
+    from src.process.bridge_processor import process_bridges
+    from src.process.extent_library import create_extent_lib
+
+    print("Setting up mock data and CollectionData...")
+    collection = create_mock_collection_data()
+
+    print(f"Library dir: {collection.library_dir}")
+    print(f"Submodels dir: {collection.submodels_dir}")
+    print(f"Extent library dir: {collection.extent_library_dir}")
+    print(f"Bridge index (S3): {collection.bridge_tile_index_path}")
+
+    print("\n" + "=" * 50)
+    print("Step 1: Running bridge processor...")
+    print("=" * 50)
+    result = process_bridges(collection, print_progress=True)
+
+    # Display files that had bridges masked
+    print("\n" + "-" * 50)
+    print(f"Files with bridges masked: {len(result['with_bridges'])}")
+    print("-" * 50)
+    if result["with_bridges"]:
+        for f in result["with_bridges"]:
+            print(f"  {f}")
+    else:
+        print("  (none)")
+
+    print(f"\nFiles without bridges: {len(result['without_bridges'])}")
+
+    print("\n" + "=" * 50)
+    print("Step 2: Running extent library creation...")
+    print("=" * 50)
+    create_extent_lib(collection, print_progress=True)
+
+    print("\n" + "=" * 50)
+    print("All processing steps complete!")
+    print("=" * 50)
+
+
+if __name__ == "__main__":
+    test_bridge_processor()

--- a/tests/test_config.yaml
+++ b/tests/test_config.yaml
@@ -2,7 +2,7 @@ RIPPLE1D_VERSION: 0.10.4
 database:
   DB_CONN_TIMEOUT: 30
 execution:
-  OPTIMUM_PARALLEL_PROCESS_COUNT: 22
+  OPTIMUM_PARALLEL_PROCESS_COUNT: 7
   stop_on_error: false
 flows2fim:
   FLOWS2FIM_BIN_PATH: C:\OSGeo4W\bin\flows2fim.exe

--- a/tests/test_config.yaml
+++ b/tests/test_config.yaml
@@ -1,0 +1,123 @@
+RIPPLE1D_VERSION: 0.10.4
+database:
+  DB_CONN_TIMEOUT: 30
+execution:
+  OPTIMUM_PARALLEL_PROCESS_COUNT: 22
+  stop_on_error: false
+flows2fim:
+  FLOWS2FIM_BIN_PATH: C:\OSGeo4W\bin\flows2fim.exe
+  FLOW_FILES_DIR: C:\reference_data\flow_files
+  GDAL_BINS_PATH: ''
+  GDAL_SCRIPTS_PATH: ''
+paths:
+  BRIDGE_TILE_INDEX_PATH: s3://fimc-data/benchmark/stac-bench-cat/assets/bridge_index.parquet
+  COLLECTIONS_ROOT_DIR: /home/dylan.lee/ripple1d-pipeline/data
+  MONITORING_DB_PATH: Z:\shared\monitoring.sqlite
+  NWM_FLOWLINES_PATH: C:\reference_data\nwm_flowlines.parquet
+  S3_UPLOAD_FAILED_PREFIX: ''
+  S3_UPLOAD_PREFIX: ''
+polling:
+  API_LAUNCH_JOBS_RETRY_WAIT: 0.5
+  DEFAULT_POLL_WAIT: 5
+processing_steps:
+  conflate_model:
+    api_process_name: conflate_model
+    domain: model
+    payload_template:
+      max_flow_multiplier: 1.5
+      min_flow_multiplier: 0.9
+      model_name: '{model_name}'
+      source_model_directory: '{source_model_directory}\{model_id}'
+      source_network:
+        file_name: C:\reference_data\nwm_flowlines_with_bbox.parquet
+        type: nwm_hydrofabric
+        version: '2.1'
+  create_fim_lib:
+    api_process_name: create_fim_lib
+    domain: reach
+    payload_template:
+      cleanup: true
+      cog: true
+      library_directory: '{library_directory}'
+      plans:
+      - nd
+      - kwse
+      resolution: 3.0
+      resolution_units: Meters
+      submodel_directory: '{submodels_directory}\{nwm_reach_id}'
+  create_model_run_normal_depth:
+    api_process_name: create_model_run_normal_depth
+    domain: reach
+    payload_template:
+      num_of_discharges_for_initial_normal_depth_runs: 15
+      plan_suffix: ind
+      ras_version: '631'
+      submodel_directory: '{submodels_directory}\{nwm_reach_id}'
+  create_ras_terrain:
+    api_process_name: create_ras_terrain
+    domain: reach
+    payload_template:
+      resolution: 3.0
+      resolution_units: Meters
+      submodel_directory: '{submodels_directory}\{nwm_reach_id}'
+      terrain_agreement_ignore_error: true
+      terrain_source_url: C:\reference_data\dem\seamless_3dep_dem_3m_5070.vrt
+  extract_submodel:
+    api_process_name: extract_submodel
+    domain: reach
+    payload_template:
+      max_flow_multiplier_ras: 1.2
+      min_flow_multiplier_ras: 1
+      model_name: '{model_name}'
+      nwm_id: '{nwm_reach_id}'
+      source_model_directory: '{source_model_directory}\{model_id}'
+      submodel_directory: '{submodels_directory}\{nwm_reach_id}'
+  ikwse_create_rating_curves_db:
+    domain: reach
+  kwse_create_rating_curves_db:
+    api_process_name: create_rating_curves_db
+    domain: reach
+    payload_template:
+      plans:
+      - kwse
+      submodel_directory: '{submodels_directory}\{nwm_reach_id}'
+  nd_create_rating_curves_db:
+    api_process_name: create_rating_curves_db
+    domain: reach
+    payload_template:
+      plans:
+      - nd
+      submodel_directory: '{submodels_directory}\{nwm_reach_id}'
+  run_iknown_wse:
+    domain: reach
+  run_incremental_normal_depth:
+    api_process_name: run_incremental_normal_depth
+    domain: reach
+    payload_template:
+      depth_increment: 0.5
+      plan_suffix: nd
+      ras_version: '631'
+      submodel_directory: '{submodels_directory}\{nwm_reach_id}'
+  run_known_wse:
+    api_process_name: run_known_wse
+    domain: reach
+    payload_template:
+      depth_increment: 1
+      max_elevation: -9999
+      min_elevation: -9999
+      plan_suffix: kwse
+      ras_version: '631'
+      submodel_directory: '{submodels_directory}\{nwm_reach_id}'
+      write_depth_grids: true
+qc:
+  QC_TEMPLATE_QGIS_FILE: C:\reference_data\qc_map.qgs
+ripple_settings:
+  DS_DEPTH_INCREMENT: 1
+  RAS_VERSION: '631'
+  RESOLUTION: 3.0
+  RESOLUTION_UNITS: Meters
+  SOURCE_NETWORK: C:\reference_data\nwm_flowlines_with_bbox.parquet
+  SOURCE_NETWORK_TYPE: nwm_hydrofabric
+  SOURCE_NETWORK_VERSION: '2.1'
+  TERRAIN_SOURCE_URL: C:\reference_data\dem\seamless_3dep_dem_3m_5070.vrt
+  US_DEPTH_INCREMENT: 0.5

--- a/tests/test_config.yaml
+++ b/tests/test_config.yaml
@@ -1,8 +1,11 @@
 RIPPLE1D_VERSION: 0.10.4
+bridge_processing:
+  BRIDGE_ELEV_CONV_FACTOR: 3.28084
+  BRIDGE_ELEV_UNITS: meters
 database:
   DB_CONN_TIMEOUT: 30
 execution:
-  OPTIMUM_PARALLEL_PROCESS_COUNT: 7
+  OPTIMUM_PARALLEL_PROCESS_COUNT: 22
   stop_on_error: false
 flows2fim:
   FLOWS2FIM_BIN_PATH: C:\OSGeo4W\bin\flows2fim.exe

--- a/tests/test_config.yaml
+++ b/tests/test_config.yaml
@@ -13,8 +13,8 @@ flows2fim:
   GDAL_BINS_PATH: ''
   GDAL_SCRIPTS_PATH: ''
 paths:
-  BRIDGE_TILE_INDEX_PATH: s3://fimc-data/benchmark/stac-bench-cat/assets/bridge_index.parquet
-  COLLECTIONS_ROOT_DIR: /home/dylan.lee/ripple1d-pipeline/data
+  BRIDGE_TILE_INDEX_PATH: /vsis3/fimc-data/benchmark/stac-bench-cat/assets/bridge_index.parquet
+  COLLECTIONS_ROOT_DIR: /work/data
   MONITORING_DB_PATH: Z:\shared\monitoring.sqlite
   NWM_FLOWLINES_PATH: C:\reference_data\nwm_flowlines.parquet
   S3_UPLOAD_FAILED_PREFIX: ''

--- a/tools/make_tile_index.py
+++ b/tools/make_tile_index.py
@@ -1,0 +1,147 @@
+import argparse
+import os
+from multiprocessing import Pool
+
+from osgeo import gdal, ogr
+
+# Enable GDAL exceptions for better error handling
+gdal.UseExceptions()
+
+
+def list_vsi_tifs(path):
+    """
+    Recursively list TIF files using GDAL's VSI file system handler.
+    """
+    print(f"Listing files in {path} (this may take a while)...")
+    try:
+        # ReadDirRecursive returns relative paths from the directory
+        files = gdal.ReadDirRecursive(path)
+        # Reconstruct full /vsis3/ paths
+        full_paths = [os.path.join(path, f) for f in files if f.lower().endswith(".tif")]
+        return full_paths
+    except Exception as e:
+        print(f"Error listing files: {e}")
+        return []
+
+
+def build_tileindex(args):
+    """
+    Worker function to build a tile index for a chunk of rasters.
+    """
+    idx, rasters, tmp_dir = args
+    out_name = os.path.join(tmp_dir, f"tmp_index_{idx}.gpkg")
+
+    # Ensure no stale file exists
+    if os.path.exists(out_name):
+        try:
+            os.remove(out_name)
+        except OSError:
+            pass
+
+    try:
+        # gdal.TileIndex is the Python binding for gdaltindex
+        gdal.TileIndex(out_name, rasters)
+        return out_name
+    except Exception as e:
+        print(f"Error processing chunk {idx}: {e}")
+        return None
+
+
+def merge_gpkgs(gpkgs, output_file):
+    """
+    Merges multiple GPKGs into a single master GPKG.
+    """
+    print(f"Merging {len(gpkgs)} temporary files into {output_file}...")
+
+    driver = ogr.GetDriverByName("GPKG")
+    if os.path.exists(output_file):
+        driver.DeleteDataSource(output_file)
+
+    out_ds = driver.CreateDataSource(output_file)
+    out_layer = None
+
+    # Iterate through temporary GPKGs
+    for gpkg_path in gpkgs:
+        if not gpkg_path or not os.path.exists(gpkg_path):
+            continue
+
+        ds = ogr.Open(gpkg_path)
+        if ds is None:
+            continue
+
+        in_layer = ds.GetLayer()
+
+        # If this is the first layer, clone its structure to create the output layer
+        if out_layer is None:
+            out_layer = out_ds.CopyLayer(in_layer, "index")
+        else:
+            # For subsequent layers, copy features into the existing output layer
+            # Using transactions significantly speeds up SQLite inserts
+            out_layer.StartTransaction()
+            for feat in in_layer:
+                new_feat = ogr.Feature(out_layer.GetLayerDefn())
+
+                # Copy Geometry
+                geom = feat.GetGeometryRef()
+                if geom:
+                    new_feat.SetGeometry(geom.Clone())
+
+                # Copy Attributes
+                for i in range(feat.GetFieldCount()):
+                    new_feat.SetField(i, feat.GetField(i))
+
+                out_layer.CreateFeature(new_feat)
+                new_feat = None
+            out_layer.CommitTransaction()
+
+        ds = None  # Close input DS
+
+    out_ds = None  # Close and flush output DS
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Parallel Tile Index Creator for S3 Rasters")
+
+    parser.add_argument("--s3-path", required=True, help="S3 path (e.g., /vsis3/bucket/folder)")
+    parser.add_argument("--final-gpkg", required=True, help="Output GeoPackage filename")
+    parser.add_argument("--processes", type=int, default=20, help="Number of parallel processes")
+    parser.add_argument("--chunk-size", type=int, default=300, help="Number of rasters per temporary GPKG")
+
+    args = parser.parse_args()
+
+    tifs = list_vsi_tifs(args.s3_path)
+    print(f"Found {len(tifs)} TIFFs.")
+
+    if len(tifs) == 0:
+        print("No TIFFs found. Exiting.")
+        return
+
+    chunks = [tifs[i : i + args.chunk_size] for i in range(0, len(tifs), args.chunk_size)]
+    print(f"Processing {len(chunks)} chunks with {args.processes} processes...")
+
+    # Prepare arguments for map (idx, chunk_list, temp_dir)
+    map_args = [(i, chunk, ".") for i, chunk in enumerate(chunks)]
+
+    with Pool(args.processes) as p:
+        tmp_indexes = p.map(build_tileindex, map_args)
+
+    # Filter out any Nones in case of errors
+    valid_indexes = [x for x in tmp_indexes if x is not None]
+
+    if valid_indexes:
+        merge_gpkgs(valid_indexes, args.final_gpkg)
+        print(f"DONE. Output saved to: {args.final_gpkg}")
+
+        print("Cleaning up temporary files...")
+        for f in valid_indexes:
+            try:
+                if os.path.exists(f):
+                    os.remove(f)
+            except Exception as e:
+                print(f"Warning: Could not delete temp file {f}: {e}")
+    else:
+        print("No temporary indexes were created. Check errors above.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds functionality to mask ripple library depth grids where flood depth estimates are covered by a higher elevation bridge. Changes include:

- Added a bridge processor script `bridge_processor.py` to `src/process`. The main entrypoint is `process_bridges`
- Added a lightweight test script in a `test` directory that acquires mock data for a given library, creates a CollectionData object, and then runs `process_bridges` and `create_extent_lib`. I'm fine with removing this after @ar-siddiqui or someone else has had a chance to test the bridge processor
- Updated requirements.txt to add libraries for interacting with the tile index on S3
- Added some additional fields to config.yaml to point to the bridge tile index as well as include information for converting the bridge raster elevation to the units of the depth library and terrain submodel
- Added a script to make bridge tile index to the tools directory. The advantage of this script over the gdal command line tool gdaltindex is that it can process rasters in parallel.
- Changed the F string formatting in 4 locations in other processes in `src/process` since this was causing an issue with initializing the processes on the linux python environment I was doing the development on.